### PR TITLE
add option to skip tls verification

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,11 +1,12 @@
 package gokong
 
 import (
-	"github.com/google/go-querystring/query"
 	"net/url"
 	"os"
 	"reflect"
 	"strings"
+
+	"github.com/google/go-querystring/query"
 )
 
 const EnvKongAdminHostAddress = "KONG_ADMIN_ADDR"
@@ -17,9 +18,10 @@ type KongAdminClient struct {
 }
 
 type Config struct {
-	HostAddress string
-	Username    string
-	Password    string
+	HostAddress        string
+	Username           string
+	Password           string
+	InsecureSkipVerify bool
 }
 
 func addQueryString(currentUrl string, filter interface{}) (string, error) {
@@ -44,9 +46,10 @@ func addQueryString(currentUrl string, filter interface{}) (string, error) {
 
 func NewDefaultConfig() *Config {
 	config := &Config{
-		HostAddress: "http://localhost:8001",
-		Username:    "",
-		Password:    "",
+		HostAddress:        "http://localhost:8001",
+		Username:           "",
+		Password:           "",
+		InsecureSkipVerify: false,
 	}
 
 	if os.Getenv(EnvKongAdminHostAddress) != "" {

--- a/request.go
+++ b/request.go
@@ -1,11 +1,13 @@
 package gokong
 
 import (
+	"crypto/tls"
+
 	"github.com/parnurzeal/gorequest"
 )
 
 func NewRequest(adminConfig *Config) *gorequest.SuperAgent {
-	request := gorequest.New()
+	request := gorequest.New().TLSClientConfig(&tls.Config{InsecureSkipVerify: adminConfig.InsecureSkipVerify})
 	if adminConfig.Username != "" || adminConfig.Password != "" {
 		request.SetBasicAuth(adminConfig.Username, adminConfig.Password)
 	}


### PR DESCRIPTION
I'm running the admin api behind an ELB with TLS and using [terraform-ssh-provider](https://github.com/stefansundin/terraform-provider-ssh) to provision resources to kong with [terraform-provider-kong](https://github.com/kevholditch/terraform-provider-kong). The ssh provider opens a local proxy allowing me to specify localhost as the admin endpoint, but this results in an invalid certificate error. 