### PR TITLE
unauthorised requests return error

### DIFF
--- a/api_key_test.go
+++ b/api_key_test.go
@@ -56,11 +56,11 @@ func Test_ApiKeyPassedViaHeader(t *testing.T) {
 	fmt.Print(key)
 
 	kongApiAddress := os.Getenv(EnvKongApiHostAddress) + "/admin-api"
-	testClient := NewClient(&Config{HostAddress: kongApiAddress})
+	unauthorisedClient := NewClient(&Config{HostAddress: kongApiAddress})
 
-	api, err := testClient.Apis().GetByName("admin-api")
+	api, err := unauthorisedClient.Apis().GetByName("admin-api")
 
-	assert.Nil(t, err)
+	assert.NotNil(t, err)
 	assert.Nil(t, api)
 
 	authorisedClient := NewClient(&Config{HostAddress: kongApiAddress, ApiKey: key})
@@ -70,6 +70,10 @@ func Test_ApiKeyPassedViaHeader(t *testing.T) {
 	assert.NotNil(t, api)
 
 	err = client.Plugins().DeleteById(createdPlugin.Id)
+
+	assert.Nil(t, err)
+
+	err = client.Apis().DeleteById(*createdApi.Id)
 
 	assert.Nil(t, err)
 

--- a/api_key_test.go
+++ b/api_key_test.go
@@ -2,7 +2,6 @@ package gokong
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"testing"
 
@@ -52,9 +51,6 @@ func Test_ApiKeyPassedViaHeader(t *testing.T) {
 	m := make(map[string]interface{})
 	json.Unmarshal([]byte(c.Body), &m)
 
-	key := m["key"].(string)
-	fmt.Print(key)
-
 	kongApiAddress := os.Getenv(EnvKongApiHostAddress) + "/admin-api"
 	unauthorisedClient := NewClient(&Config{HostAddress: kongApiAddress})
 
@@ -63,7 +59,7 @@ func Test_ApiKeyPassedViaHeader(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Nil(t, api)
 
-	authorisedClient := NewClient(&Config{HostAddress: kongApiAddress, ApiKey: key})
+	authorisedClient := NewClient(&Config{HostAddress: kongApiAddress, ApiKey: m["key"].(string)})
 
 	api, err = authorisedClient.Apis().GetByName("admin-api")
 	assert.Nil(t, err)

--- a/apis.go
+++ b/apis.go
@@ -67,10 +67,14 @@ func (apiClient *ApiClient) GetByName(name string) (*Api, error) {
 }
 
 func (apiClient *ApiClient) GetById(id string) (*Api, error) {
-	_, body, errs := newGet(apiClient.config, apiClient.config.HostAddress+ApisPath+id).End()
+	r, body, errs := newGet(apiClient.config, apiClient.config.HostAddress+ApisPath+id).End()
 
 	if errs != nil {
 		return nil, fmt.Errorf("could not get api, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	api := &Api{}
@@ -98,9 +102,13 @@ func (apiClient *ApiClient) ListFiltered(filter *ApiFilter) (*Apis, error) {
 		return nil, fmt.Errorf("could not build query string for apis filter, error: %v", err)
 	}
 
-	_, body, errs := newGet(apiClient.config, address).End()
+	r, body, errs := newGet(apiClient.config, address).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get apis, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	apis := &Apis{}
@@ -114,9 +122,13 @@ func (apiClient *ApiClient) ListFiltered(filter *ApiFilter) (*Apis, error) {
 
 func (apiClient *ApiClient) Create(newApi *ApiRequest) (*Api, error) {
 
-	_, body, errs := newPost(apiClient.config, apiClient.config.HostAddress+ApisPath).Send(newApi).End()
+	r, body, errs := newPost(apiClient.config, apiClient.config.HostAddress+ApisPath).Send(newApi).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not create new api, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	createdApi := &Api{}
@@ -138,9 +150,13 @@ func (apiClient *ApiClient) DeleteByName(name string) error {
 
 func (apiClient *ApiClient) DeleteById(id string) error {
 
-	res, _, errs := newDelete(apiClient.config, apiClient.config.HostAddress+ApisPath+id).End()
+	r, body, errs := newDelete(apiClient.config, apiClient.config.HostAddress+ApisPath+id).End()
 	if errs != nil {
-		return fmt.Errorf("could not delete api, result: %v error: %v", res, errs)
+		return fmt.Errorf("could not delete api, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	return nil
@@ -152,13 +168,13 @@ func (apiClient *ApiClient) UpdateByName(name string, apiRequest *ApiRequest) (*
 
 func (apiClient *ApiClient) UpdateById(id string, apiRequest *ApiRequest) (*Api, error) {
 
-	j, _ := json.Marshal(apiRequest)
-	js := string(j)
-	fmt.Sprintf("%s", js)
-
-	_, body, errs := newPatch(apiClient.config, apiClient.config.HostAddress+ApisPath+id).Send(apiRequest).End()
+	r, body, errs := newPatch(apiClient.config, apiClient.config.HostAddress+ApisPath+id).Send(apiRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update api, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	updatedApi := &Api{}

--- a/apis_test.go
+++ b/apis_test.go
@@ -3,6 +3,10 @@ package gokong
 import (
 	"testing"
 
+	"encoding/json"
+	"fmt"
+	"os"
+
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 )
@@ -767,5 +771,88 @@ func Test_ApisUpdateToEmptyMethodsArray(t *testing.T) {
 	assert.Equal(t, apiRequest.UpstreamReadTimeout, result.UpstreamReadTimeout)
 	assert.Equal(t, apiRequest.HttpsOnly, result.HttpsOnly)
 	assert.Equal(t, apiRequest.HttpIfTerminated, result.HttpIfTerminated)
+
+}
+
+func Test_AllApiEndpointsShouldReturnErrorWhenRequestUnauthorised(t *testing.T) {
+
+	apiRequest := &ApiRequest{
+		Name:        String("admin-api"),
+		Uris:        StringSlice([]string{"/admin-api"}),
+		UpstreamUrl: String("http://localhost:8001"),
+	}
+
+	client := NewClient(NewDefaultConfig())
+	createdApi, err := client.Apis().Create(apiRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdApi)
+
+	consumerRequest := &ConsumerRequest{
+		Username: "username-" + uuid.NewV4().String(),
+		CustomId: "test-" + uuid.NewV4().String(),
+	}
+
+	createdConsumer, err := client.Consumers().Create(consumerRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdConsumer)
+
+	pluginRequest := &PluginRequest{
+		Name:  "key-auth",
+		ApiId: *createdApi.Id,
+		Config: map[string]interface{}{
+			"hide_credentials": true,
+		},
+	}
+
+	createdPlugin, err := client.Plugins().Create(pluginRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdPlugin)
+
+	c, err := client.Consumers().CreatePluginConfig(createdConsumer.Id, "key-auth", "")
+
+	m := make(map[string]interface{})
+	json.Unmarshal([]byte(c.Body), &m)
+
+	key := m["key"].(string)
+	fmt.Print(key)
+
+	kongApiAddress := os.Getenv(EnvKongApiHostAddress) + "/admin-api"
+	unauthorisedClient := NewClient(&Config{HostAddress: kongApiAddress})
+
+	api, err := unauthorisedClient.Apis().GetByName("admin-api")
+	assert.NotNil(t, err)
+	assert.Nil(t, api)
+
+	results, err := unauthorisedClient.Apis().List()
+	assert.NotNil(t, err)
+	assert.Nil(t, results)
+
+	err = unauthorisedClient.Apis().DeleteById(*createdApi.Id)
+	assert.NotNil(t, err)
+
+	apiResult, err := unauthorisedClient.Apis().Create(&ApiRequest{
+		Name:        String("test-" + uuid.NewV4().String()),
+		Uris:        StringSlice([]string{"/admin-api"}),
+		UpstreamUrl: String("http://localhost:4140"),
+	})
+	assert.Nil(t, apiResult)
+	assert.NotNil(t, err)
+
+	updatedApi, err := unauthorisedClient.Apis().UpdateById(*createdApi.Id, &ApiRequest{
+		Name:        String("admin-api-updated"),
+		Uris:        StringSlice([]string{"/admin-api"}),
+		UpstreamUrl: String("http://localhost:8001"),
+	})
+	assert.Nil(t, updatedApi)
+	assert.NotNil(t, err)
+
+	err = client.Plugins().DeleteById(createdPlugin.Id)
+	assert.Nil(t, err)
+
+	err = client.Apis().DeleteById(*createdApi.Id)
+	assert.Nil(t, err)
 
 }

--- a/certificates.go
+++ b/certificates.go
@@ -29,9 +29,13 @@ const CertificatesPath = "/certificates/"
 
 func (certificateClient *CertificateClient) GetById(id string) (*Certificate, error) {
 
-	_, body, errs := newGet(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath+id).End()
+	r, body, errs := newGet(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath+id).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get certificate, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	certificate := &Certificate{}
@@ -49,9 +53,13 @@ func (certificateClient *CertificateClient) GetById(id string) (*Certificate, er
 
 func (certificateClient *CertificateClient) Create(certificateRequest *CertificateRequest) (*Certificate, error) {
 
-	_, body, errs := newPost(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath).Send(certificateRequest).End()
+	r, body, errs := newPost(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath).Send(certificateRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not create new certificate, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	createdCertificate := &Certificate{}
@@ -69,9 +77,13 @@ func (certificateClient *CertificateClient) Create(certificateRequest *Certifica
 
 func (certificateClient *CertificateClient) DeleteById(id string) error {
 
-	res, _, errs := newDelete(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath+id).End()
+	r, body, errs := newDelete(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath+id).End()
 	if errs != nil {
-		return fmt.Errorf("could not delete certificate, result: %v error: %v", res, errs)
+		return fmt.Errorf("could not delete certificate, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	return nil
@@ -79,9 +91,13 @@ func (certificateClient *CertificateClient) DeleteById(id string) error {
 
 func (certificateClient *CertificateClient) List() (*Certificates, error) {
 
-	_, body, errs := newGet(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath).End()
+	r, body, errs := newGet(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get certificates, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	certificates := &Certificates{}
@@ -95,9 +111,13 @@ func (certificateClient *CertificateClient) List() (*Certificates, error) {
 
 func (certificateClient *CertificateClient) UpdateById(id string, certificateRequest *CertificateRequest) (*Certificate, error) {
 
-	_, body, errs := newPatch(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath+id).Send(certificateRequest).End()
+	r, body, errs := newPatch(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath+id).Send(certificateRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update certificate, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	updatedCertificate := &Certificate{}

--- a/consumers.go
+++ b/consumers.go
@@ -47,9 +47,13 @@ func (consumerClient *ConsumerClient) GetByUsername(username string) (*Consumer,
 
 func (consumerClient *ConsumerClient) GetById(id string) (*Consumer, error) {
 
-	_, body, errs := newGet(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+id).End()
+	r, body, errs := newGet(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+id).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get consumer, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	consumer := &Consumer{}
@@ -67,9 +71,13 @@ func (consumerClient *ConsumerClient) GetById(id string) (*Consumer, error) {
 
 func (consumerClient *ConsumerClient) Create(consumerRequest *ConsumerRequest) (*Consumer, error) {
 
-	_, body, errs := newPost(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath).Send(consumerRequest).End()
+	r, body, errs := newPost(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath).Send(consumerRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not create new consumer, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	createdConsumer := &Consumer{}
@@ -97,9 +105,13 @@ func (consumerClient *ConsumerClient) ListFiltered(filter *ConsumerFilter) (*Con
 		return nil, fmt.Errorf("could not build query string for consumer filter, error: %v", err)
 	}
 
-	_, body, errs := newGet(consumerClient.config, address).End()
+	r, body, errs := newGet(consumerClient.config, address).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get consumers, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	consumers := &Consumers{}
@@ -117,9 +129,13 @@ func (consumerClient *ConsumerClient) DeleteByUsername(username string) error {
 
 func (consumerClient *ConsumerClient) DeleteById(id string) error {
 
-	res, _, errs := newDelete(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+id).End()
+	r, body, errs := newDelete(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+id).End()
 	if errs != nil {
-		return fmt.Errorf("could not delete consumer, result: %v error: %v", res, errs)
+		return fmt.Errorf("could not delete consumer, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	return nil
@@ -131,9 +147,13 @@ func (consumerClient *ConsumerClient) UpdateByUsername(username string, consumer
 
 func (consumerClient *ConsumerClient) UpdateById(id string, consumerRequest *ConsumerRequest) (*Consumer, error) {
 
-	_, body, errs := newPatch(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+id).Send(consumerRequest).End()
+	r, body, errs := newPatch(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+id).Send(consumerRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update consumer, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	updatedConsumer := &Consumer{}
@@ -151,9 +171,13 @@ func (consumerClient *ConsumerClient) UpdateById(id string, consumerRequest *Con
 
 func (consumerClient *ConsumerClient) CreatePluginConfig(consumerId string, pluginName string, pluginConfig string) (*ConsumerPluginConfig, error) {
 
-	_, body, errs := newPost(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName).Send(pluginConfig).End()
+	r, body, errs := newPost(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName).Send(pluginConfig).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not configure plugin for consumer, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	createdConsumerPluginConfig := &ConsumerPluginConfig{}
@@ -173,9 +197,13 @@ func (consumerClient *ConsumerClient) CreatePluginConfig(consumerId string, plug
 
 func (consumerClient *ConsumerClient) GetPluginConfig(consumerId string, pluginName string, id string) (*ConsumerPluginConfig, error) {
 
-	_, body, errs := newGet(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName+"/"+id).End()
+	r, body, errs := newGet(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName+"/"+id).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get plugin config for consumer, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	consumerPluginConfig := &ConsumerPluginConfig{}
@@ -195,9 +223,13 @@ func (consumerClient *ConsumerClient) GetPluginConfig(consumerId string, pluginN
 
 func (consumerClient *ConsumerClient) DeletePluginConfig(consumerId string, pluginName string, id string) error {
 
-	_, _, errs := newDelete(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName+"/"+id).End()
+	r, body, errs := newDelete(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName+"/"+id).End()
 	if errs != nil {
 		return fmt.Errorf("could not delete plugin config for consumer, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	return nil

--- a/consumers_test.go
+++ b/consumers_test.go
@@ -3,6 +3,8 @@ package gokong
 import (
 	"testing"
 
+	"os"
+
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 )
@@ -443,6 +445,102 @@ func Test_ConsumersPluginConfig(t *testing.T) {
 	retrievedPluginConfig, err = client.Consumers().GetPluginConfig(createdConsumer.Id, "jwt", createdPluginConfig.Id)
 
 	assert.Nil(t, retrievedPluginConfig)
+	assert.Nil(t, err)
+
+}
+
+func Test_AllConsumerEndpointsShouldReturnErrorWhenRequestUnauthorised(t *testing.T) {
+
+	apiRequest := &ApiRequest{
+		Name:        String("admin-api"),
+		Uris:        StringSlice([]string{"/admin-api"}),
+		UpstreamUrl: String("http://localhost:8001"),
+	}
+
+	client := NewClient(NewDefaultConfig())
+	createdApi, err := client.Apis().Create(apiRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdApi)
+
+	consumerRequest := &ConsumerRequest{
+		Username: "username-" + uuid.NewV4().String(),
+		CustomId: "test-" + uuid.NewV4().String(),
+	}
+
+	createdConsumer, err := client.Consumers().Create(consumerRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdConsumer)
+
+	pluginRequest := &PluginRequest{
+		Name:  "key-auth",
+		ApiId: *createdApi.Id,
+		Config: map[string]interface{}{
+			"hide_credentials": true,
+		},
+	}
+
+	createdPlugin, err := client.Plugins().Create(pluginRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdPlugin)
+
+	_, err = client.Consumers().CreatePluginConfig(createdConsumer.Id, "key-auth", "")
+	assert.Nil(t, err)
+
+	kongApiAddress := os.Getenv(EnvKongApiHostAddress) + "/admin-api"
+	unauthorisedClient := NewClient(&Config{HostAddress: kongApiAddress})
+
+	consumer, err := unauthorisedClient.Consumers().GetById(createdConsumer.Id)
+	assert.NotNil(t, err)
+	assert.Nil(t, consumer)
+
+	consumer, err = unauthorisedClient.Consumers().GetByUsername(createdConsumer.Username)
+	assert.NotNil(t, err)
+	assert.Nil(t, consumer)
+
+	results, err := unauthorisedClient.Consumers().List()
+	assert.NotNil(t, err)
+	assert.Nil(t, results)
+
+	err = unauthorisedClient.Consumers().DeleteById(createdConsumer.Id)
+	assert.NotNil(t, err)
+
+	err = unauthorisedClient.Consumers().DeleteByUsername(createdConsumer.Username)
+	assert.NotNil(t, err)
+
+	createNewConsumer := &ConsumerRequest{
+		Username: "username-" + uuid.NewV4().String(),
+		CustomId: "test-" + uuid.NewV4().String(),
+	}
+	newConsumer, err := unauthorisedClient.Consumers().Create(createNewConsumer)
+	assert.Nil(t, newConsumer)
+	assert.NotNil(t, err)
+
+	updatedConsumer, err := unauthorisedClient.Consumers().UpdateById(createdConsumer.Id, createNewConsumer)
+	assert.Nil(t, updatedConsumer)
+	assert.NotNil(t, err)
+
+	updatedConsumer, err = unauthorisedClient.Consumers().UpdateByUsername(createdConsumer.Username, createNewConsumer)
+	assert.Nil(t, updatedConsumer)
+	assert.NotNil(t, err)
+
+	createdPluginConfig, err := unauthorisedClient.Consumers().CreatePluginConfig(createdConsumer.Id, "jwt", "{\"key\": \"a36c3049b36249a3c9f8891cb127243c\"}")
+	assert.Nil(t, createdPluginConfig)
+	assert.NotNil(t, err)
+
+	pluginConfig, err := unauthorisedClient.Consumers().GetPluginConfig(createdConsumer.Id, "jwt", "id")
+	assert.Nil(t, pluginConfig)
+	assert.NotNil(t, err)
+
+	err = unauthorisedClient.Consumers().DeletePluginConfig(createdConsumer.Id, "jwt", "id")
+	assert.NotNil(t, err)
+
+	err = client.Plugins().DeleteById(createdPlugin.Id)
+	assert.Nil(t, err)
+
+	err = client.Apis().DeleteById(*createdApi.Id)
 	assert.Nil(t, err)
 
 }

--- a/plugins.go
+++ b/plugins.go
@@ -50,9 +50,13 @@ const PluginsPath = "/plugins/"
 
 func (pluginClient *PluginClient) GetById(id string) (*Plugin, error) {
 
-	_, body, errs := newGet(pluginClient.config, pluginClient.config.HostAddress+PluginsPath+id).End()
+	r, body, errs := newGet(pluginClient.config, pluginClient.config.HostAddress+PluginsPath+id).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get plugin, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	plugin := &Plugin{}
@@ -80,9 +84,13 @@ func (pluginClient *PluginClient) ListFiltered(filter *PluginFilter) (*Plugins, 
 		return nil, fmt.Errorf("could not build query string for plugins filter, error: %v", err)
 	}
 
-	_, body, errs := newGet(pluginClient.config, address).End()
+	r, body, errs := newGet(pluginClient.config, address).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get plugins, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	plugins := &Plugins{}
@@ -96,9 +104,13 @@ func (pluginClient *PluginClient) ListFiltered(filter *PluginFilter) (*Plugins, 
 
 func (pluginClient *PluginClient) Create(pluginRequest *PluginRequest) (*Plugin, error) {
 
-	_, body, errs := newPost(pluginClient.config, pluginClient.config.HostAddress+PluginsPath).Send(pluginRequest).End()
+	r, body, errs := newPost(pluginClient.config, pluginClient.config.HostAddress+PluginsPath).Send(pluginRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not create new plugin, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	createdPlugin := &Plugin{}
@@ -116,9 +128,13 @@ func (pluginClient *PluginClient) Create(pluginRequest *PluginRequest) (*Plugin,
 
 func (pluginClient *PluginClient) UpdateById(id string, pluginRequest *PluginRequest) (*Plugin, error) {
 
-	_, body, errs := newPatch(pluginClient.config, pluginClient.config.HostAddress+PluginsPath+id).Send(pluginRequest).End()
+	r, body, errs := newPatch(pluginClient.config, pluginClient.config.HostAddress+PluginsPath+id).Send(pluginRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update plugin, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	updatedPlugin := &Plugin{}
@@ -136,9 +152,13 @@ func (pluginClient *PluginClient) UpdateById(id string, pluginRequest *PluginReq
 
 func (pluginClient *PluginClient) DeleteById(id string) error {
 
-	res, _, errs := newDelete(pluginClient.config, pluginClient.config.HostAddress+PluginsPath+id).End()
+	r, body, errs := newDelete(pluginClient.config, pluginClient.config.HostAddress+PluginsPath+id).End()
 	if errs != nil {
-		return fmt.Errorf("could not delete plugin, result: %v error: %v", res, errs)
+		return fmt.Errorf("could not delete plugin, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	return nil

--- a/routes.go
+++ b/routes.go
@@ -51,9 +51,13 @@ type RouteQueryString struct {
 const RoutesPath = "/routes/"
 
 func (routeClient *RouteClient) AddRoute(routeRequest *RouteRequest) (*Route, error) {
-	_, body, errs := newPost(routeClient.config, routeClient.config.HostAddress+RoutesPath).Send(routeRequest).End()
+	r, body, errs := newPost(routeClient.config, routeClient.config.HostAddress+RoutesPath).Send(routeRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not register the route, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	createdRoute := &Route{}
@@ -70,9 +74,13 @@ func (routeClient *RouteClient) AddRoute(routeRequest *RouteRequest) (*Route, er
 }
 
 func (routeClient *RouteClient) GetRoute(id string) (*Route, error) {
-	_, body, errs := newGet(routeClient.config, routeClient.config.HostAddress+RoutesPath+id).End()
+	r, body, errs := newGet(routeClient.config, routeClient.config.HostAddress+RoutesPath+id).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get the route, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	route := &Route{}
@@ -101,9 +109,13 @@ func (routeClient *RouteClient) GetRoutes(query *RouteQueryString) ([]*Route, er
 	}
 
 	for {
-		_, body, errs := newGet(routeClient.config, routeClient.config.HostAddress+RoutesPath).Query(query).End()
+		r, body, errs := newGet(routeClient.config, routeClient.config.HostAddress+RoutesPath).Query(query).End()
 		if errs != nil {
 			return nil, fmt.Errorf("could not get the route, error: %v", errs)
+		}
+
+		if r.StatusCode == 401 || r.StatusCode == 403 {
+			return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 		}
 
 		err := json.Unmarshal([]byte(body), data)
@@ -132,9 +144,13 @@ func (routeClient *RouteClient) GetRoutesFromServiceId(id string) ([]*Route, err
 	data := &Routes{}
 
 	for {
-		_, body, errs := newGet(routeClient.config, routeClient.config.HostAddress+fmt.Sprintf("/services/%s/routes", id)).End()
+		r, body, errs := newGet(routeClient.config, routeClient.config.HostAddress+fmt.Sprintf("/services/%s/routes", id)).End()
 		if errs != nil {
 			return nil, fmt.Errorf("could not get the route, error: %v", errs)
+		}
+
+		if r.StatusCode == 401 || r.StatusCode == 403 {
+			return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 		}
 
 		err := json.Unmarshal([]byte(body), data)
@@ -153,9 +169,13 @@ func (routeClient *RouteClient) GetRoutesFromServiceId(id string) ([]*Route, err
 }
 
 func (routeClient *RouteClient) UpdateRoute(id string, routeRequest *RouteRequest) (*Route, error) {
-	_, body, errs := newPatch(routeClient.config, routeClient.config.HostAddress+RoutesPath+id).Send(routeRequest).End()
+	r, body, errs := newPatch(routeClient.config, routeClient.config.HostAddress+RoutesPath+id).Send(routeRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update route, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	updatedRoute := &Route{}
@@ -172,9 +192,13 @@ func (routeClient *RouteClient) UpdateRoute(id string, routeRequest *RouteReques
 }
 
 func (routeClient *RouteClient) DeleteRoute(id string) error {
-	res, _, errs := newDelete(routeClient.config, routeClient.config.HostAddress+RoutesPath+id).End()
+	r, body, errs := newDelete(routeClient.config, routeClient.config.HostAddress+RoutesPath+id).End()
 	if errs != nil {
-		return fmt.Errorf("could not delete the route, result: %v error: %v", res, errs)
+		return fmt.Errorf("could not delete the route, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	return nil

--- a/routes_test.go
+++ b/routes_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"os"
+
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 )
@@ -357,6 +359,126 @@ func TestRouteClient_UpdateRoutePathsToEmptyArray(t *testing.T) {
 	assert.Equal(t, StringSlice([]string{}), fetchedRoute.Paths)
 	assert.Equal(t, routeRequest.StripPath, fetchedRoute.StripPath)
 	assert.Equal(t, routeRequest.PreserveHost, fetchedRoute.PreserveHost)
+
+	err = client.Routes().DeleteRoute(*createdRoute.Id)
+	assert.Nil(t, err)
+
+	err = client.Services().DeleteServiceById(*createdService.Id)
+	assert.Nil(t, err)
+
+}
+
+func Test_AllRouteEndpointsShouldReturnErrorWhenRequestUnauthorised(t *testing.T) {
+
+	apiRequest := &ApiRequest{
+		Name:        String("admin-api"),
+		Uris:        StringSlice([]string{"/admin-api"}),
+		UpstreamUrl: String("http://localhost:8001"),
+	}
+
+	client := NewClient(NewDefaultConfig())
+	createdApi, err := client.Apis().Create(apiRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdApi)
+
+	consumerRequest := &ConsumerRequest{
+		Username: "username-" + uuid.NewV4().String(),
+		CustomId: "test-" + uuid.NewV4().String(),
+	}
+
+	createdConsumer, err := client.Consumers().Create(consumerRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdConsumer)
+
+	pluginRequest := &PluginRequest{
+		Name:  "key-auth",
+		ApiId: *createdApi.Id,
+		Config: map[string]interface{}{
+			"hide_credentials": true,
+		},
+	}
+
+	createdPlugin, err := client.Plugins().Create(pluginRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdPlugin)
+
+	_, err = client.Consumers().CreatePluginConfig(createdConsumer.Id, "key-auth", "")
+	assert.Nil(t, err)
+
+	serviceRequest := &ServiceRequest{
+		Name:     String("service-name" + uuid.NewV4().String()),
+		Protocol: String("http"),
+		Host:     String("foo.com"),
+	}
+
+	createdService, err := client.Services().AddService(serviceRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdService)
+
+	routeRequest := &RouteRequest{
+		Protocols:    StringSlice([]string{"http"}),
+		Methods:      StringSlice([]string{"GET"}),
+		Hosts:        StringSlice([]string{"foo.com"}),
+		Paths:        StringSlice([]string{"/bar"}),
+		StripPath:    Bool(true),
+		PreserveHost: Bool(true),
+		Service:      &RouteServiceObject{Id: *createdService.Id},
+	}
+
+	createdRoute, err := client.Routes().AddRoute(routeRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdRoute)
+
+	kongApiAddress := os.Getenv(EnvKongApiHostAddress) + "/admin-api"
+	unauthorisedClient := NewClient(&Config{HostAddress: kongApiAddress})
+
+	r, err := unauthorisedClient.Routes().GetRoute(*createdRoute.Id)
+	assert.NotNil(t, err)
+	assert.Nil(t, r)
+
+	results, err := unauthorisedClient.Routes().GetRoutes(&RouteQueryString{})
+	assert.NotNil(t, err)
+	assert.Nil(t, results)
+
+	results, err = unauthorisedClient.Routes().GetRoutesFromServiceId(*createdService.Id)
+	assert.NotNil(t, err)
+	assert.Nil(t, results)
+
+	results, err = unauthorisedClient.Routes().GetRoutesFromServiceName(*createdService.Name)
+	assert.NotNil(t, err)
+	assert.Nil(t, results)
+
+	err = unauthorisedClient.Routes().DeleteRoute(*createdRoute.Id)
+	assert.NotNil(t, err)
+
+	createNewRouteRequest := &RouteRequest{
+		Protocols:    StringSlice([]string{"http"}),
+		Methods:      StringSlice([]string{"POST"}),
+		Hosts:        StringSlice([]string{"foo.com"}),
+		Paths:        StringSlice([]string{"/bar"}),
+		StripPath:    Bool(true),
+		PreserveHost: Bool(true),
+		Service:      &RouteServiceObject{Id: *createdService.Id},
+	}
+
+	newRoute, err := unauthorisedClient.Routes().AddRoute(createNewRouteRequest)
+	assert.Nil(t, newRoute)
+	assert.NotNil(t, err)
+
+	updatedRoute, err := unauthorisedClient.Routes().UpdateRoute(*createdRoute.Id, createNewRouteRequest)
+	assert.Nil(t, updatedRoute)
+	assert.NotNil(t, err)
+
+	err = client.Plugins().DeleteById(createdPlugin.Id)
+	assert.Nil(t, err)
+
+	err = client.Apis().DeleteById(*createdApi.Id)
+	assert.Nil(t, err)
 
 	err = client.Routes().DeleteRoute(*createdRoute.Id)
 	assert.Nil(t, err)

--- a/services.go
+++ b/services.go
@@ -70,9 +70,13 @@ func (serviceClient *ServiceClient) AddService(serviceRequest *ServiceRequest) (
 		serviceRequest.Retries = Int(60000)
 	}
 
-	_, body, errs := newPost(serviceClient.config, serviceClient.config.HostAddress+ServicesPath).Send(serviceRequest).End()
+	r, body, errs := newPost(serviceClient.config, serviceClient.config.HostAddress+ServicesPath).Send(serviceRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not register the service, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	createdService := &Service{}
@@ -101,9 +105,13 @@ func (serviceClient *ServiceClient) GetServiceFromRouteId(id string) (*Service, 
 }
 
 func (serviceClient *ServiceClient) getService(endpoint string) (*Service, error) {
-	_, body, errs := newGet(serviceClient.config, endpoint).End()
+	r, body, errs := newGet(serviceClient.config, endpoint).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get the service, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	service := &Service{}
@@ -132,9 +140,13 @@ func (serviceClient *ServiceClient) GetServices(query *ServiceQueryString) ([]*S
 	}
 
 	for {
-		_, body, errs := newGet(serviceClient.config, serviceClient.config.HostAddress+ServicesPath).Query(query).End()
+		r, body, errs := newGet(serviceClient.config, serviceClient.config.HostAddress+ServicesPath).Query(query).End()
 		if errs != nil {
 			return nil, fmt.Errorf("could not get the service, error: %v", errs)
+		}
+
+		if r.StatusCode == 401 || r.StatusCode == 403 {
+			return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 		}
 
 		err := json.Unmarshal([]byte(body), data)
@@ -167,9 +179,13 @@ func (serviceClient *ServiceClient) UpdateServicebyRouteId(id string, serviceReq
 }
 
 func (serviceClient *ServiceClient) updateService(endpoint string, serviceRequest *ServiceRequest) (*Service, error) {
-	_, body, errs := newPatch(serviceClient.config, endpoint).Send(serviceRequest).End()
+	r, body, errs := newPatch(serviceClient.config, endpoint).Send(serviceRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update service, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	updatedService := &Service{}
@@ -190,9 +206,13 @@ func (serviceClient *ServiceClient) DeleteServiceByName(name string) error {
 }
 
 func (serviceClient *ServiceClient) DeleteServiceById(id string) error {
-	res, _, errs := newDelete(serviceClient.config, serviceClient.config.HostAddress+ServicesPath+id).End()
+	r, body, errs := newDelete(serviceClient.config, serviceClient.config.HostAddress+ServicesPath+id).End()
 	if errs != nil {
-		return fmt.Errorf("could not delete the service, result: %v error: %v", res, errs)
+		return fmt.Errorf("could not delete the service, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	return nil

--- a/services_test.go
+++ b/services_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"os"
+
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 )
@@ -107,4 +109,105 @@ func Test_ServicesGetNonExistentByName(t *testing.T) {
 
 	assert.Nil(t, service)
 	assert.Nil(t, err)
+}
+
+func Test_AllServiceEndpointsShouldReturnErrorWhenRequestUnauthorised(t *testing.T) {
+
+	apiRequest := &ApiRequest{
+		Name:        String("admin-api"),
+		Uris:        StringSlice([]string{"/admin-api"}),
+		UpstreamUrl: String("http://localhost:8001"),
+	}
+
+	client := NewClient(NewDefaultConfig())
+	createdApi, err := client.Apis().Create(apiRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdApi)
+
+	consumerRequest := &ConsumerRequest{
+		Username: "username-" + uuid.NewV4().String(),
+		CustomId: "test-" + uuid.NewV4().String(),
+	}
+
+	createdConsumer, err := client.Consumers().Create(consumerRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdConsumer)
+
+	pluginRequest := &PluginRequest{
+		Name:  "key-auth",
+		ApiId: *createdApi.Id,
+		Config: map[string]interface{}{
+			"hide_credentials": true,
+		},
+	}
+
+	createdPlugin, err := client.Plugins().Create(pluginRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdPlugin)
+
+	_, err = client.Consumers().CreatePluginConfig(createdConsumer.Id, "key-auth", "")
+	assert.Nil(t, err)
+
+	serviceRequest := &ServiceRequest{
+		Name:     String("service-name" + uuid.NewV4().String()),
+		Protocol: String("http"),
+		Host:     String("foo.com"),
+	}
+
+	createdService, err := client.Services().AddService(serviceRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdService)
+
+	kongApiAddress := os.Getenv(EnvKongApiHostAddress) + "/admin-api"
+	unauthorisedClient := NewClient(&Config{HostAddress: kongApiAddress})
+
+	s, err := unauthorisedClient.Services().GetServiceByName(*createdService.Name)
+	assert.NotNil(t, err)
+	assert.Nil(t, s)
+
+	s, err = unauthorisedClient.Services().GetServiceById(*createdService.Id)
+	assert.NotNil(t, err)
+	assert.Nil(t, s)
+
+	results, err := unauthorisedClient.Services().GetServices(&ServiceQueryString{})
+	assert.NotNil(t, err)
+	assert.Nil(t, results)
+
+	err = unauthorisedClient.Services().DeleteServiceById(*createdService.Id)
+	assert.NotNil(t, err)
+
+	err = unauthorisedClient.Services().DeleteServiceByName(*createdService.Name)
+	assert.NotNil(t, err)
+
+	createServiceRequest := &ServiceRequest{
+		Name:     String("service-name" + uuid.NewV4().String()),
+		Protocol: String("http"),
+		Host:     String("foo.com"),
+	}
+
+	newService, err := unauthorisedClient.Services().AddService(createServiceRequest)
+	assert.Nil(t, newService)
+	assert.NotNil(t, err)
+
+	updatedService, err := unauthorisedClient.Services().UpdateServiceById(*createdService.Id, createServiceRequest)
+	assert.Nil(t, updatedService)
+	assert.NotNil(t, err)
+
+	updatedService, err = unauthorisedClient.Services().UpdateServiceByName(*createdService.Name, createServiceRequest)
+	assert.Nil(t, updatedService)
+	assert.NotNil(t, err)
+
+	err = client.Plugins().DeleteById(createdPlugin.Id)
+	assert.Nil(t, err)
+
+	err = client.Apis().DeleteById(*createdApi.Id)
+	assert.Nil(t, err)
+
+	err = client.Services().DeleteServiceById(*createdService.Id)
+	assert.Nil(t, err)
+
 }

--- a/snis.go
+++ b/snis.go
@@ -28,9 +28,13 @@ const SnisPath = "/snis/"
 
 func (snisClient *SnisClient) Create(snisRequest *SnisRequest) (*Sni, error) {
 
-	_, body, errs := newPost(snisClient.config, snisClient.config.HostAddress+SnisPath).Send(snisRequest).End()
+	r, body, errs := newPost(snisClient.config, snisClient.config.HostAddress+SnisPath).Send(snisRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not create new sni, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	sni := &Sni{}
@@ -48,9 +52,13 @@ func (snisClient *SnisClient) Create(snisRequest *SnisRequest) (*Sni, error) {
 
 func (snisClient *SnisClient) GetByName(name string) (*Sni, error) {
 
-	_, body, errs := newGet(snisClient.config, snisClient.config.HostAddress+SnisPath+name).End()
+	r, body, errs := newGet(snisClient.config, snisClient.config.HostAddress+SnisPath+name).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get sni, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	sni := &Sni{}
@@ -68,9 +76,13 @@ func (snisClient *SnisClient) GetByName(name string) (*Sni, error) {
 
 func (snisClient *SnisClient) List() (*Snis, error) {
 
-	_, body, errs := newGet(snisClient.config, snisClient.config.HostAddress+SnisPath).End()
+	r, body, errs := newGet(snisClient.config, snisClient.config.HostAddress+SnisPath).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get snis, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	snis := &Snis{}
@@ -84,9 +96,13 @@ func (snisClient *SnisClient) List() (*Snis, error) {
 
 func (snisClient *SnisClient) DeleteByName(name string) error {
 
-	res, _, errs := newDelete(snisClient.config, snisClient.config.HostAddress+SnisPath+name).End()
+	r, body, errs := newDelete(snisClient.config, snisClient.config.HostAddress+SnisPath+name).End()
 	if errs != nil {
-		return fmt.Errorf("could not delete sni, result: %v error: %v", res, errs)
+		return fmt.Errorf("could not delete sni, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	return nil
@@ -94,9 +110,13 @@ func (snisClient *SnisClient) DeleteByName(name string) error {
 
 func (snisClient *SnisClient) UpdateByName(name string, snisRequest *SnisRequest) (*Sni, error) {
 
-	_, body, errs := newPatch(snisClient.config, snisClient.config.HostAddress+SnisPath+name).Send(snisRequest).End()
+	r, body, errs := newPatch(snisClient.config, snisClient.config.HostAddress+SnisPath+name).Send(snisRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update sni, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	updatedSni := &Sni{}

--- a/snis_test.go
+++ b/snis_test.go
@@ -3,6 +3,8 @@ package gokong
 import (
 	"testing"
 
+	"os"
+
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 )
@@ -220,5 +222,97 @@ func Test_SnisUpdateByNameInvalid(t *testing.T) {
 
 	assert.NotNil(t, err)
 	assert.Nil(t, result)
+
+}
+
+func Test_AllSniEndpointsShouldReturnErrorWhenRequestUnauthorised(t *testing.T) {
+
+	apiRequest := &ApiRequest{
+		Name:        String("admin-api"),
+		Uris:        StringSlice([]string{"/admin-api"}),
+		UpstreamUrl: String("http://localhost:8001"),
+	}
+
+	client := NewClient(NewDefaultConfig())
+	createdApi, err := client.Apis().Create(apiRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdApi)
+
+	consumerRequest := &ConsumerRequest{
+		Username: "username-" + uuid.NewV4().String(),
+		CustomId: "test-" + uuid.NewV4().String(),
+	}
+
+	createdConsumer, err := client.Consumers().Create(consumerRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdConsumer)
+
+	pluginRequest := &PluginRequest{
+		Name:  "key-auth",
+		ApiId: *createdApi.Id,
+		Config: map[string]interface{}{
+			"hide_credentials": true,
+		},
+	}
+
+	createdPlugin, err := client.Plugins().Create(pluginRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdPlugin)
+
+	_, err = client.Consumers().CreatePluginConfig(createdConsumer.Id, "key-auth", "")
+	assert.Nil(t, err)
+
+	certificate, err := client.Certificates().Create(&CertificateRequest{
+		Cert: String("public key-" + uuid.NewV4().String()),
+		Key:  String("private key-" + uuid.NewV4().String()),
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, certificate)
+
+	snisRequest := &SnisRequest{
+		Name:             uuid.NewV4().String() + ".example.com",
+		SslCertificateId: *certificate.Id,
+	}
+
+	createdSni, err := client.Snis().Create(snisRequest)
+	assert.Nil(t, err)
+	assert.NotNil(t, createdSni)
+
+	kongApiAddress := os.Getenv(EnvKongApiHostAddress) + "/admin-api"
+	unauthorisedClient := NewClient(&Config{HostAddress: kongApiAddress})
+
+	sni, err := unauthorisedClient.Snis().GetByName(createdSni.Name)
+	assert.NotNil(t, err)
+	assert.Nil(t, sni)
+
+	results, err := unauthorisedClient.Snis().List()
+	assert.NotNil(t, err)
+	assert.Nil(t, results)
+
+	err = unauthorisedClient.Snis().DeleteByName(createdSni.Name)
+	assert.NotNil(t, err)
+
+	sniResult, err := unauthorisedClient.Snis().Create(&SnisRequest{
+		Name:             uuid.NewV4().String() + ".example.com",
+		SslCertificateId: *certificate.Id,
+	})
+	assert.Nil(t, sniResult)
+	assert.NotNil(t, err)
+
+	updatedSni, err := unauthorisedClient.Snis().UpdateByName(createdSni.Name, &SnisRequest{
+		Name:             uuid.NewV4().String() + ".example.com",
+		SslCertificateId: *certificate.Id,
+	})
+	assert.Nil(t, updatedSni)
+	assert.NotNil(t, err)
+
+	err = client.Plugins().DeleteById(createdPlugin.Id)
+	assert.Nil(t, err)
+
+	err = client.Apis().DeleteById(*createdApi.Id)
+	assert.Nil(t, err)
 
 }

--- a/upstreams.go
+++ b/upstreams.go
@@ -91,9 +91,13 @@ func (upstreamClient *UpstreamClient) GetByName(name string) (*Upstream, error) 
 
 func (upstreamClient *UpstreamClient) GetById(id string) (*Upstream, error) {
 
-	_, body, errs := newGet(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath+id).End()
+	r, body, errs := newGet(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath+id).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get upstream, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	upstream := &Upstream{}
@@ -111,9 +115,13 @@ func (upstreamClient *UpstreamClient) GetById(id string) (*Upstream, error) {
 
 func (upstreamClient *UpstreamClient) Create(upstreamRequest *UpstreamRequest) (*Upstream, error) {
 
-	_, body, errs := newPost(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath).Send(upstreamRequest).End()
+	r, body, errs := newPost(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath).Send(upstreamRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not create new upstream, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	createdUpstream := &Upstream{}
@@ -135,9 +143,13 @@ func (upstreamClient *UpstreamClient) DeleteByName(name string) error {
 
 func (upstreamClient *UpstreamClient) DeleteById(id string) error {
 
-	res, _, errs := newDelete(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath+id).End()
+	r, body, errs := newDelete(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath+id).End()
 	if errs != nil {
-		return fmt.Errorf("could not delete upstream, result: %v error: %v", res, errs)
+		return fmt.Errorf("could not delete upstream, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	return nil
@@ -155,9 +167,13 @@ func (upstreamClient *UpstreamClient) ListFiltered(filter *UpstreamFilter) (*Ups
 		return nil, fmt.Errorf("could not build query string for upstreams filter, error: %v", err)
 	}
 
-	_, body, errs := newGet(upstreamClient.config, address).End()
+	r, body, errs := newGet(upstreamClient.config, address).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get upstreams, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	upstreams := &Upstreams{}
@@ -175,9 +191,13 @@ func (upstreamClient *UpstreamClient) UpdateByName(name string, upstreamRequest 
 
 func (upstreamClient *UpstreamClient) UpdateById(id string, upstreamRequest *UpstreamRequest) (*Upstream, error) {
 
-	_, body, errs := newPatch(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath+id).Send(upstreamRequest).End()
+	r, body, errs := newPatch(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath+id).Send(upstreamRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update upstream, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	updatedUpstream := &Upstream{}

--- a/upstreams_test.go
+++ b/upstreams_test.go
@@ -3,6 +3,8 @@ package gokong
 import (
 	"testing"
 
+	"os"
+
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 )
@@ -467,5 +469,105 @@ func Test_UpstreamsUpdateByNameInvalid(t *testing.T) {
 
 	assert.NotNil(t, err)
 	assert.Nil(t, result)
+
+}
+
+func Test_AllUpstreamEndpointsShouldReturnErrorWhenRequestUnauthorised(t *testing.T) {
+
+	apiRequest := &ApiRequest{
+		Name:        String("admin-api"),
+		Uris:        StringSlice([]string{"/admin-api"}),
+		UpstreamUrl: String("http://localhost:8001"),
+	}
+
+	client := NewClient(NewDefaultConfig())
+	createdApi, err := client.Apis().Create(apiRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdApi)
+
+	consumerRequest := &ConsumerRequest{
+		Username: "username-" + uuid.NewV4().String(),
+		CustomId: "test-" + uuid.NewV4().String(),
+	}
+
+	createdConsumer, err := client.Consumers().Create(consumerRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdConsumer)
+
+	pluginRequest := &PluginRequest{
+		Name:  "key-auth",
+		ApiId: *createdApi.Id,
+		Config: map[string]interface{}{
+			"hide_credentials": true,
+		},
+	}
+
+	createdPlugin, err := client.Plugins().Create(pluginRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdPlugin)
+
+	_, err = client.Consumers().CreatePluginConfig(createdConsumer.Id, "key-auth", "")
+	assert.Nil(t, err)
+
+	upstreamRequest := &UpstreamRequest{
+		Name:  "upstream-" + uuid.NewV4().String(),
+		Slots: 10,
+	}
+
+	createdUpstream, err := client.Upstreams().Create(upstreamRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdUpstream)
+
+	kongApiAddress := os.Getenv(EnvKongApiHostAddress) + "/admin-api"
+	unauthorisedClient := NewClient(&Config{HostAddress: kongApiAddress})
+
+	upstream, err := unauthorisedClient.Upstreams().GetByName(createdUpstream.Name)
+	assert.NotNil(t, err)
+	assert.Nil(t, upstream)
+
+	upstream, err = unauthorisedClient.Upstreams().GetById(createdUpstream.Id)
+	assert.NotNil(t, err)
+	assert.Nil(t, upstream)
+
+	results, err := unauthorisedClient.Upstreams().List()
+	assert.NotNil(t, err)
+	assert.Nil(t, results)
+
+	err = unauthorisedClient.Upstreams().DeleteByName(createdUpstream.Name)
+	assert.NotNil(t, err)
+
+	err = unauthorisedClient.Upstreams().DeleteById(createdUpstream.Id)
+	assert.NotNil(t, err)
+
+	upstreamResult, err := unauthorisedClient.Upstreams().Create(&UpstreamRequest{
+		Name:  "upstream-" + uuid.NewV4().String(),
+		Slots: 10,
+	})
+	assert.Nil(t, upstreamResult)
+	assert.NotNil(t, err)
+
+	updatedUpstream, err := unauthorisedClient.Upstreams().UpdateByName(createdUpstream.Name, &UpstreamRequest{
+		Name:  "upstream-" + uuid.NewV4().String(),
+		Slots: 10,
+	})
+	assert.Nil(t, updatedUpstream)
+	assert.NotNil(t, err)
+
+	updatedUpstream, err = unauthorisedClient.Upstreams().UpdateById(createdUpstream.Id, &UpstreamRequest{
+		Name:  "upstream-" + uuid.NewV4().String(),
+		Slots: 10,
+	})
+	assert.Nil(t, updatedUpstream)
+	assert.NotNil(t, err)
+
+	err = client.Plugins().DeleteById(createdPlugin.Id)
+	assert.Nil(t, err)
+
+	err = client.Apis().DeleteById(*createdApi.Id)
+	assert.Nil(t, err)
 
 }


### PR DESCRIPTION
previously when requests were unauthorised the error was swalled so nil would be returned
in the case where you were creating a resource you would get nil, nil.  There is a bug
in the terraform provider that uses go kong: https://github.com/kevholditch/terraform-provider-kong/issues/18
caused by this.

Added tests to cover every endpoint returns an error when requests are not authorised