### PR TITLE
Adding url "shorthand" attribute to service request object

### DIFF
--- a/services.go
+++ b/services.go
@@ -19,6 +19,7 @@ type ServiceRequest struct {
 	ConnectTimeout *int    `json:"connect_timeout,omitempty"`
 	WriteTimeout   *int    `json:"write_timeout,omitempty"`
 	ReadTimeout    *int    `json:"read_timeout,omitempty"`
+	Url            *string `json:"url,omitempty"`
 }
 
 type Service struct {

--- a/services_test.go
+++ b/services_test.go
@@ -39,6 +39,33 @@ func TestServiceClient_GetServiceById(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestServiceClient_GetServiceByIdWithUrl(t *testing.T) {
+	serviceRequest := &ServiceRequest{
+		Name: String(fmt.Sprintf("service-name-%s", uuid.NewV4().String())),
+		Url:  String("http://foo.com:8080"),
+	}
+
+	client := NewClient(NewDefaultConfig())
+
+	createdService, err := client.Services().AddService(serviceRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdService)
+	assert.EqualValues(t, createdService.Name, serviceRequest.Name)
+	assert.EqualValues(t, createdService.Protocol, String("http"))
+	assert.EqualValues(t, createdService.Host, String("foo.com"))
+	assert.EqualValues(t, createdService.Port, Int(8080))
+
+	result, err := client.Services().GetServiceById(*createdService.Id)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, createdService, result)
+
+	err = client.Services().DeleteServiceById(*createdService.Id)
+	assert.Nil(t, err)
+}
+
 func TestServiceClient_GetServices(t *testing.T) {
 	serviceRequest := &ServiceRequest{
 		Protocol: String("http"),


### PR DESCRIPTION
See docs for overview -> https://docs.konghq.com/0.14.x/admin-api/#service-object. It does not come back on the response but rather the API pulls it apart and sets the 4 related properties for you (host, port, protocol, and path).