### PR TITLE
Add ListPluginConfig API for consumers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ default: build test
 build: fmtcheck errcheck vet
 	go install
 
-test: goimportscheck
+test:
 	go test -v ./...
 
 vet:

--- a/consumers_test.go
+++ b/consumers_test.go
@@ -434,6 +434,12 @@ func Test_ConsumersPluginConfig(t *testing.T) {
 	assert.NotEqual(t, "", createdPluginConfig.Id)
 	assert.Contains(t, createdPluginConfig.Body, "a36c3049b36249a3c9f8891cb127243c")
 
+	retrievedPluginConfigs, err := client.Consumers().ListPluginConfig(createdConsumer.Id, "jwt")
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1, retrievedPluginConfigs.Total)
+	assert.Equal(t, createdPluginConfig, retrievedPluginConfigs.Results[0])
+
 	retrievedPluginConfig, err := client.Consumers().GetPluginConfig(createdConsumer.Id, "jwt", createdPluginConfig.Id)
 
 	assert.Nil(t, err)


### PR DESCRIPTION
Add an API method to list all the consumer plugin configurations.

Maybe this will work for the latest supported kong too, can make a separate PR to the master branch if it makes sense.  Just needed it here for now.