### PR TITLE
Add support for Targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ services:
   - docker
 env:
   matrix:
-    - KONG_VERSION=1.0.1
+    - KONG_VERSION=1.0.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ services:
   - docker
 env:
   matrix:
-    - KONG_VERSION=1.0.0
+    - KONG_VERSION=1.0.1

--- a/README.md
+++ b/README.md
@@ -593,6 +593,45 @@ updateUpstreamRequest := &gokong.UpstreamRequest{
 updatedUpstream, err := gokong.NewClient(gokong.NewDefaultConfig()).Upstreams().UpdateByName("test-upstream", updateUpstreamRequest)
 ```
 
+## Targets
+Create a target for an upstream ([for more information on the Target Fields see the Kong documentation](https://getkong.org/docs/0.13.x/admin-api/#upstream-objects)):
+```go
+targetRequest := &TargetRequest{
+  Target:				"foo.com:443",
+  Weight:				100,
+}
+createdTarget, err := gokong.NewClient(gokong.NewDefaultConfig()).Targets().CreateFromUpstreamId("upstreamId", targetRequest)
+```
+
+List all targets for an upstream
+```go
+targets, err := gokong.NewClient(gokong.NewDefaultConfig()).Targets().GetTargetsFromUpstreamId("upstreamId")
+```
+
+Delete a target from an upstream
+```go
+targets, err := gokong.NewClient(gokong.NewDefaultConfig()).Targets().DeleteFromUpstreamById("upstreamId")
+```
+
+Set target as healthy
+```go
+targets, err := gokong.NewClient(gokong.NewDefaultConfig()).Targets().SetTargetFromUpstreamByIdAsHealthy("upstreamId")
+```
+
+Set target as unhealthy
+```go
+targets, err := gokong.NewClient(gokong.NewDefaultConfig()).Targets().SetTargetFromUpstreamByIdAsUnhealthy("upstreamId")
+```
+
+List all targets for an upstream (including health status)
+```go
+targets, err := gokong.NewClient(gokong.NewDefaultConfig()).Targets().GetTargetsWithHealthFromUpstreamName(upstreamId)
+```
+
+**Notes**: Target methods listed above are overloaded in the same fashion as other objects exposed by this library. For parameters:
+ - upstream - either name of id can be used
+ - target - either id or target name (host:port) can be used
+
 # Contributing
 I would love to get contributions to the project so please feel free to submit a PR.  To setup your dev station you need go and docker installed.
 

--- a/client.go
+++ b/client.go
@@ -137,3 +137,9 @@ func (kongAdminClient *KongAdminClient) Services() *ServiceClient {
 		config: kongAdminClient.config,
 	}
 }
+
+func (kongAdminClient *KongAdminClient) Targets() *TargetClient {
+	return &TargetClient{
+		config: kongAdminClient.config,
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const defaultKongVersion = "1.0.0"
+const defaultKongVersion = "1.0.2"
 const kong401Server = "KONG_401_SERVER"
 
 func Test_Newclient(t *testing.T) {

--- a/targets.go
+++ b/targets.go
@@ -10,30 +10,30 @@ type TargetClient struct {
 }
 
 type TargetRequest struct {
-	Target        string         `json:"target"`
-	Weight        int            `json:"weight"`
+	Target string `json:"target"`
+	Weight int    `json:"weight"`
 }
 
 type Target struct {
-	Id            *string        `json:"id,omitempty"`
-  CreatedAt     *float32       `json:"created_at"`
-  Target        *string        `json:"target"`
-  Weight        *int           `json:"weight"`
-  Upstream      *Id            `json:"upstream"`
-	Health        *string        `json:"health"`
+	Id        *string  `json:"id,omitempty"`
+	CreatedAt *float32 `json:"created_at"`
+	Target    *string  `json:"target"`
+	Weight    *int     `json:"weight"`
+	Upstream  *Id      `json:"upstream"`
+	Health    *string  `json:"health"`
 }
 
 type Targets struct {
-  Data          []*Target      `json:"data"`
-  Total         int            `json:"total,omitempty"`
-	Next          string         `json:"next,omitempty"`
-	NodeId        string         `json:"node_id,omitempty"`
+	Data   []*Target `json:"data"`
+	Total  int       `json:"total,omitempty"`
+	Next   string    `json:"next,omitempty"`
+	NodeId string    `json:"node_id,omitempty"`
 }
 
 const TargetsPath = "/upstreams/%s/targets"
 
 func (targetClient *TargetClient) CreateFromUpstreamName(name string, targetRequest *TargetRequest) (*Target, error) {
-    return targetClient.CreateFromUpstreamId(name, targetRequest)
+	return targetClient.CreateFromUpstreamId(name, targetRequest)
 }
 
 func (targetClient *TargetClient) CreateFromUpstreamId(id string, targetRequest *TargetRequest) (*Target, error) {

--- a/targets.go
+++ b/targets.go
@@ -1,0 +1,202 @@
+package gokong
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type TargetClient struct {
+	config *Config
+}
+
+type TargetRequest struct {
+	Target        string         `json:"target"`
+	Weight        int            `json:"weight"`
+}
+
+type Target struct {
+	Id            *string        `json:"id,omitempty"`
+  CreatedAt     *float32       `json:"created_at"`
+  Target        *string        `json:"target"`
+  Weight        *int           `json:"weight"`
+  Upstream      *Id            `json:"upstream"`
+	Health        *string        `json:"health"`
+}
+
+type Targets struct {
+  Data          []*Target      `json:"data"`
+  Total         int            `json:"total,omitempty"`
+	Next          string         `json:"next,omitempty"`
+	NodeId        string         `json:"node_id,omitempty"`
+}
+
+const TargetsPath = "/upstreams/%s/targets"
+
+func (targetClient *TargetClient) CreateFromUpstreamName(name string, targetRequest *TargetRequest) (*Target, error) {
+    return targetClient.CreateFromUpstreamId(name, targetRequest)
+}
+
+func (targetClient *TargetClient) CreateFromUpstreamId(id string, targetRequest *TargetRequest) (*Target, error) {
+	r, body, errs := newPost(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf(TargetsPath, id)).Send(targetRequest).End()
+	if errs != nil {
+		return nil, fmt.Errorf("could not register the target, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	createdTarget := &Target{}
+	err := json.Unmarshal([]byte(body), createdTarget)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse target get response, error: %v", err)
+	}
+
+	if createdTarget.Id == nil {
+		return nil, fmt.Errorf("could not register the target, error: %v", body)
+	}
+
+	return createdTarget, nil
+}
+
+func (targetClient *TargetClient) GetTargetsFromUpstreamName(name string) ([]*Target, error) {
+	return targetClient.GetTargetsFromUpstreamId(name)
+}
+
+func (targetClient *TargetClient) GetTargetsFromUpstreamId(id string) ([]*Target, error) {
+	targets := []*Target{}
+	data := &Targets{}
+
+	for {
+		r, body, errs := newGet(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf(TargetsPath, id)).End()
+		if errs != nil {
+			return nil, fmt.Errorf("could not get targets, error: %v", errs)
+		}
+
+		if r.StatusCode == 401 || r.StatusCode == 403 {
+			return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+		}
+
+		if r.StatusCode == 404 {
+			return nil, fmt.Errorf("non existent upstream: %s", id)
+		}
+
+		err := json.Unmarshal([]byte(body), data)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse target get response, error: %v", err)
+		}
+
+		targets = append(targets, data.Data...)
+
+		if data.Next == "" {
+			break
+		}
+	}
+	return targets, nil
+}
+
+func (targetClient *TargetClient) DeleteFromUpstreamByHostPort(upstreamNameOrId string, hostPort string) error {
+	return targetClient.DeleteFromUpstreamById(upstreamNameOrId, hostPort)
+}
+
+func (targetClient *TargetClient) DeleteFromUpstreamById(upstreamNameOrId string, id string) error {
+	r, body, errs := newDelete(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf(TargetsPath, upstreamNameOrId)+fmt.Sprintf("/%s", id)).End()
+	if errs != nil {
+		return fmt.Errorf("could not delete the target, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode != 204 {
+		return fmt.Errorf("Received unexpected response status code: %d. Body: %s", r.StatusCode, body)
+	}
+
+	return nil
+}
+
+func (targetClient *TargetClient) SetTargetFromUpstreamByHostPortAsHealthy(upstreamNameOrId string, hostPort string) error {
+	return targetClient.SetTargetFromUpstreamByIdAsHealthy(upstreamNameOrId, hostPort)
+}
+
+func (targetClient *TargetClient) SetTargetFromUpstreamByIdAsHealthy(upstreamNameOrId string, id string) error {
+	r, body, errs := newPost(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf(TargetsPath, upstreamNameOrId)+fmt.Sprintf("/%s/healthy", id)).Send("").End()
+	if errs != nil {
+		return fmt.Errorf("could not set the target as healthy, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode != 204 {
+		return fmt.Errorf("Received unexpected response status code: %d. Body: %s", r.StatusCode, body)
+	}
+
+	return nil
+}
+
+func (targetClient *TargetClient) SetTargetFromUpstreamByHostPortAsUnhealthy(upstreamNameOrId string, hostPort string) error {
+	return targetClient.SetTargetFromUpstreamByIdAsUnhealthy(upstreamNameOrId, hostPort)
+}
+
+func (targetClient *TargetClient) SetTargetFromUpstreamByIdAsUnhealthy(upstreamNameOrId string, id string) error {
+	r, body, errs := newPost(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf(TargetsPath, upstreamNameOrId)+fmt.Sprintf("/%s/unhealthy", id)).Send("").End()
+	if errs != nil {
+		return fmt.Errorf("could not set the target as unhealthy, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode != 204 {
+		return fmt.Errorf("Received unexpected response status code: %d. Body: %s", r.StatusCode, body)
+	}
+
+	return nil
+}
+
+func (targetClient *TargetClient) GetTargetsWithHealthFromUpstreamName(name string) ([]*Target, error) {
+	return targetClient.GetTargetsWithHealthFromUpstreamId(name)
+}
+
+func (targetClient *TargetClient) GetTargetsWithHealthFromUpstreamId(id string) ([]*Target, error) {
+	targets := []*Target{}
+	data := &Targets{}
+
+	for {
+		r, body, errs := newGet(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf("/upstreams/%s/health", id)).End()
+		if errs != nil {
+			return nil, fmt.Errorf("could not get targets, error: %v", errs)
+		}
+
+		if r.StatusCode == 401 || r.StatusCode == 403 {
+			return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+		}
+
+		if r.StatusCode == 404 {
+			return nil, fmt.Errorf("non existent upstream: %s", id)
+		}
+
+		err := json.Unmarshal([]byte(body), data)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse target get response, error: %v", err)
+		}
+
+		targets = append(targets, data.Data...)
+
+		if data.Next == "" {
+			break
+		}
+	}
+	return targets, nil
+}
+
+// TODO: Implement List all Targets - https://docs.konghq.com/1.0.x/admin-api/#list-all-targets
+// Note: JSON returned by this method has slightly different structure to the standard Get request. This method retruns "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4" instead of "upstream": {"id":"127dfc88-ed57-45bf-b77a-a9d3a152ad31"},
+
+// TODO: Implement other methods available by /targets paths
+// https://docs.konghq.com/1.0.x/admin-api/#update-or-create-upstream
+// https://docs.konghq.com/1.0.x/admin-api/#delete-upstream

--- a/targets_test.go
+++ b/targets_test.go
@@ -20,7 +20,7 @@ func TestTargets_GetTargetsFromUpstreamId(t *testing.T) {
 	assert.NotNil(t, createdUpstream)
 
 	targetRequest := &TargetRequest{
-		Target: "foo.com:443",
+		Target: "www.example.com:80",
 		Weight: 200,
 	}
 	createdTarget, err := client.Targets().CreateFromUpstreamId(createdUpstream.Id, targetRequest)
@@ -52,7 +52,7 @@ func TestTargets_GetTargetsFromUpstreamName(t *testing.T) {
 	assert.NotNil(t, createdUpstream)
 
 	targetRequest := &TargetRequest{
-		Target: "foo.com:443",
+		Target: "www.example.com:80",
 		Weight: 200,
 	}
 	createdTarget, err := client.Targets().CreateFromUpstreamName(createdUpstream.Name, targetRequest)
@@ -91,7 +91,7 @@ func TestTargets_Create(t *testing.T) {
 	assert.NotNil(t, createdUpstream)
 
 	targetRequest := &TargetRequest{
-		Target: "foo.com:443",
+		Target: "www.example.com:80",
 		Weight: 200,
 	}
 	createdTarget, err := client.Targets().CreateFromUpstreamId(createdUpstream.Id, targetRequest)
@@ -119,7 +119,7 @@ func TestTargets_Delete(t *testing.T) {
 	assert.NotNil(t, createdUpstream)
 
 	targetRequest := &TargetRequest{
-		Target: "foo.com:443",
+		Target: "www.example.com:80",
 		Weight: 200,
 	}
 	createdTarget, err := client.Targets().CreateFromUpstreamId(createdUpstream.Id, targetRequest)
@@ -147,15 +147,15 @@ func TestTargets_SetTargetHealthFromUpstreamByHostPort(t *testing.T) {
 				Timeout:     1,
 				Healthy: &ActiveHealthy{
 					HttpStatuses: []int{200, 302},
-					Interval:     100,
-					Successes:    1,
+					Interval:     1000,
+					Successes:    10,
 				},
 				Unhealthy: &ActiveUnhealthy{
-					HttpFailures: 0,
+					HttpFailures: 10,
 					HttpStatuses: []int{429, 404, 500, 501, 502, 503, 504, 505},
-					Interval:     100,
-					TcpFailures:  1,
-					Timeouts:     1,
+					Interval:     1000,
+					TcpFailures:  10,
+					Timeouts:     10,
 				},
 			},
 		},
@@ -168,7 +168,7 @@ func TestTargets_SetTargetHealthFromUpstreamByHostPort(t *testing.T) {
 	assert.NotNil(t, createdUpstream)
 
 	targetRequest := &TargetRequest{
-		Target: "foo.com:443",
+		Target: "www.example.com:80",
 		Weight: 200,
 	}
 	createdTarget, err := client.Targets().CreateFromUpstreamName(createdUpstream.Name, targetRequest)

--- a/targets_test.go
+++ b/targets_test.go
@@ -181,7 +181,7 @@ func TestTargets_SetTargetHealthFromUpstreamByHostPort(t *testing.T) {
 	// and health checks for the upstream/targets by the time we start trying to set their health status below
 	targets, err := client.Targets().GetTargetsWithHealthFromUpstreamName(createdUpstream.Name)
 	retry := 1
-	for *targets[0].Health == "HEALTHCHECKS_OFF" && retry < 10 {
+	for (*targets[0].Health == "HEALTHCHECKS_OFF" || *targets[0].Health == "DNS_ERROR") && retry < 10 {
 		t.Log("Health-checks still off on target. Sleep and try again until we have another status.")
 		assert.Len(t, targets, 1)
 
@@ -190,7 +190,7 @@ func TestTargets_SetTargetHealthFromUpstreamByHostPort(t *testing.T) {
 		retry++
 	}
 
-	result := client.Targets().SetTargetFromUpstreamByHostPortAsUnhealthy(createdUpstream.Name, *createdTarget.Target)
+	result := client.Targets().SetTargetFromUpstreamByIdAsUnhealthy(createdUpstream.Id, *createdTarget.Id)
 
 	assert.Nil(t, result)
 
@@ -202,7 +202,7 @@ func TestTargets_SetTargetHealthFromUpstreamByHostPort(t *testing.T) {
 	target := targets[0]
 	assert.Equal(t, "UNHEALTHY", *target.Health)
 
-	result = client.Targets().SetTargetFromUpstreamByHostPortAsHealthy(createdUpstream.Name, *createdTarget.Target)
+	result = client.Targets().SetTargetFromUpstreamByIdAsHealthy(createdUpstream.Id, *createdTarget.Id)
 
 	assert.Nil(t, result)
 

--- a/targets_test.go
+++ b/targets_test.go
@@ -2,7 +2,7 @@ package gokong
 
 import (
 	"testing"
-	"time"
+	// "time"
 
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"

--- a/targets_test.go
+++ b/targets_test.go
@@ -20,8 +20,8 @@ func TestTargets_GetTargetsFromUpstreamId(t *testing.T) {
 	assert.NotNil(t, createdUpstream)
 
 	targetRequest := &TargetRequest{
-		Target:				"foo.com:443",
-		Weight:				200,
+		Target: "foo.com:443",
+		Weight: 200,
 	}
 	createdTarget, err := client.Targets().CreateFromUpstreamId(createdUpstream.Id, targetRequest)
 
@@ -52,8 +52,8 @@ func TestTargets_GetTargetsFromUpstreamName(t *testing.T) {
 	assert.NotNil(t, createdUpstream)
 
 	targetRequest := &TargetRequest{
-		Target:				"foo.com:443",
-		Weight:				200,
+		Target: "foo.com:443",
+		Weight: 200,
 	}
 	createdTarget, err := client.Targets().CreateFromUpstreamName(createdUpstream.Name, targetRequest)
 
@@ -91,8 +91,8 @@ func TestTargets_Create(t *testing.T) {
 	assert.NotNil(t, createdUpstream)
 
 	targetRequest := &TargetRequest{
-		Target:				"foo.com:443",
-		Weight:				200,
+		Target: "foo.com:443",
+		Weight: 200,
 	}
 	createdTarget, err := client.Targets().CreateFromUpstreamId(createdUpstream.Id, targetRequest)
 
@@ -119,8 +119,8 @@ func TestTargets_Delete(t *testing.T) {
 	assert.NotNil(t, createdUpstream)
 
 	targetRequest := &TargetRequest{
-		Target:				"foo.com:443",
-		Weight:				200,
+		Target: "foo.com:443",
+		Weight: 200,
 	}
 	createdTarget, err := client.Targets().CreateFromUpstreamId(createdUpstream.Id, targetRequest)
 
@@ -168,8 +168,8 @@ func TestTargets_SetTargetHealthFromUpstreamByHostPort(t *testing.T) {
 	assert.NotNil(t, createdUpstream)
 
 	targetRequest := &TargetRequest{
-		Target:				"foo.com:443",
-		Weight:				200,
+		Target: "foo.com:443",
+		Weight: 200,
 	}
 	createdTarget, err := client.Targets().CreateFromUpstreamName(createdUpstream.Name, targetRequest)
 

--- a/targets_test.go
+++ b/targets_test.go
@@ -1,0 +1,205 @@
+package gokong
+
+import (
+	"testing"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTargets_GetTargetsFromUpstreamId(t *testing.T) {
+	upstreamRequest := &UpstreamRequest{
+		Name:  "upstream-" + uuid.NewV4().String(),
+		Slots: 10,
+	}
+
+	client := NewClient(NewDefaultConfig())
+	createdUpstream, err := client.Upstreams().Create(upstreamRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdUpstream)
+
+	targetRequest := &TargetRequest{
+		Target:				"foo.com:443",
+		Weight:				200,
+	}
+	createdTarget, err := client.Targets().CreateFromUpstreamId(createdUpstream.Id, targetRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdTarget)
+
+	result, err := client.Targets().GetTargetsFromUpstreamId(createdUpstream.Id)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+	assert.Len(t, result, 1)
+	assert.Equal(t, createdTarget, result[0])
+
+	client.Targets().DeleteFromUpstreamById(createdUpstream.Id, *createdTarget.Id)
+	client.Upstreams().DeleteById(createdUpstream.Id)
+}
+
+func TestTargets_GetTargetsFromUpstreamName(t *testing.T) {
+	upstreamRequest := &UpstreamRequest{
+		Name:  "upstream-" + uuid.NewV4().String(),
+		Slots: 10,
+	}
+
+	client := NewClient(NewDefaultConfig())
+	createdUpstream, err := client.Upstreams().Create(upstreamRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdUpstream)
+
+	targetRequest := &TargetRequest{
+		Target:				"foo.com:443",
+		Weight:				200,
+	}
+	createdTarget, err := client.Targets().CreateFromUpstreamName(createdUpstream.Name, targetRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdTarget)
+
+	result, err := client.Targets().GetTargetsFromUpstreamName(createdUpstream.Name)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+	assert.Len(t, result, 1)
+	assert.Equal(t, createdTarget, result[0])
+
+	client.Targets().DeleteFromUpstreamById(createdUpstream.Name, *createdTarget.Target)
+	client.Upstreams().DeleteById(createdUpstream.Id)
+}
+
+func TestTargets_GetForNonExistentUpstream(t *testing.T) {
+	result, err := NewClient(NewDefaultConfig()).Targets().GetTargetsFromUpstreamName(uuid.NewV4().String())
+
+	assert.Nil(t, result)
+	assert.NotNil(t, err)
+}
+
+func TestTargets_Create(t *testing.T) {
+	upstreamRequest := &UpstreamRequest{
+		Name:  "upstream-" + uuid.NewV4().String(),
+		Slots: 10,
+	}
+
+	client := NewClient(NewDefaultConfig())
+	createdUpstream, err := client.Upstreams().Create(upstreamRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdUpstream)
+
+	targetRequest := &TargetRequest{
+		Target:				"foo.com:443",
+		Weight:				200,
+	}
+	createdTarget, err := client.Targets().CreateFromUpstreamId(createdUpstream.Id, targetRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdTarget)
+	assert.True(t, *createdTarget.Id != "")
+	assert.Equal(t, *createdTarget.Target, targetRequest.Target)
+	assert.Equal(t, *createdTarget.Weight, targetRequest.Weight)
+
+	client.Targets().DeleteFromUpstreamById(createdUpstream.Id, *createdTarget.Id)
+	client.Upstreams().DeleteById(createdUpstream.Id)
+}
+
+func TestTargets_Delete(t *testing.T) {
+	upstreamRequest := &UpstreamRequest{
+		Name:  "upstream-" + uuid.NewV4().String(),
+		Slots: 10,
+	}
+
+	client := NewClient(NewDefaultConfig())
+	createdUpstream, err := client.Upstreams().Create(upstreamRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdUpstream)
+
+	targetRequest := &TargetRequest{
+		Target:				"foo.com:443",
+		Weight:				200,
+	}
+	createdTarget, err := client.Targets().CreateFromUpstreamId(createdUpstream.Id, targetRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdTarget)
+
+	client.Targets().DeleteFromUpstreamByHostPort(createdUpstream.Name, *createdTarget.Target)
+
+	targets, err := client.Targets().GetTargetsFromUpstreamName(createdUpstream.Name)
+	assert.Nil(t, err)
+	assert.Len(t, targets, 0)
+
+	client.Upstreams().DeleteById(createdUpstream.Id)
+}
+
+func TestTargets_SetTargetHealthFromUpstreamByHostPort(t *testing.T) {
+	upstreamRequest := &UpstreamRequest{
+		Name:  "upstream-" + uuid.NewV4().String(),
+		Slots: 10,
+		HealthChecks: &UpstreamHealthCheck{
+			Active: &UpstreamHealthCheckActive{
+				Concurrency: 10,
+				HttpPath:    "/",
+				Timeout:     1,
+				Healthy: &ActiveHealthy{
+					HttpStatuses: []int{200, 302},
+					Interval:     100,
+					Successes:    1,
+				},
+				Unhealthy: &ActiveUnhealthy{
+					HttpFailures: 0,
+					HttpStatuses: []int{429, 404, 500, 501, 502, 503, 504, 505},
+					Interval:     100,
+					TcpFailures:  1,
+					Timeouts:     1,
+				},
+			},
+		},
+	}
+
+	client := NewClient(NewDefaultConfig())
+	createdUpstream, err := client.Upstreams().Create(upstreamRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdUpstream)
+
+	targetRequest := &TargetRequest{
+		Target:				"foo.com:443",
+		Weight:				200,
+	}
+	createdTarget, err := client.Targets().CreateFromUpstreamName(createdUpstream.Name, targetRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdTarget)
+
+	result := client.Targets().SetTargetFromUpstreamByHostPortAsUnhealthy(createdUpstream.Name, *createdTarget.Target)
+
+	assert.Nil(t, result)
+
+	targets, err := client.Targets().GetTargetsWithHealthFromUpstreamName(createdUpstream.Name)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, targets)
+	assert.Len(t, targets, 1)
+	target := targets[0]
+	assert.Equal(t, "UNHEALTHY", *target.Health)
+
+	result = client.Targets().SetTargetFromUpstreamByHostPortAsHealthy(createdUpstream.Name, *createdTarget.Target)
+
+	assert.Nil(t, result)
+
+	targets, err = client.Targets().GetTargetsWithHealthFromUpstreamName(createdUpstream.Name)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, targets)
+	assert.Len(t, targets, 1)
+	target = targets[0]
+	assert.Equal(t, "HEALTHY", *target.Health)
+
+	client.Targets().DeleteFromUpstreamById(createdUpstream.Name, *createdTarget.Target)
+	client.Upstreams().DeleteById(createdUpstream.Id)
+}

--- a/targets_test.go
+++ b/targets_test.go
@@ -2,6 +2,7 @@ package gokong
 
 import (
 	"testing"
+	"time"
 
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
@@ -175,6 +176,10 @@ func TestTargets_SetTargetHealthFromUpstreamByHostPort(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.NotNil(t, createdTarget)
+
+	// HACK: This is just plain old nasty - but tests fail on occassion as Kong hasn't setup the load balancer and
+	// health checks for the upstream/targets by the time we start trying to set their health status below
+	time.Sleep(2 * time.Second)
 
 	result := client.Targets().SetTargetFromUpstreamByHostPortAsUnhealthy(createdUpstream.Name, *createdTarget.Target)
 


### PR DESCRIPTION
Resolves https://github.com/kevholditch/gokong/issues/12

 - Implemented methods listed under
https://docs.konghq.com/1.0.x/admin-api/#target-object barring https://docs.konghq.com/1.0.x/admin-api/#list-all-targets.
- Exposed https://docs.konghq.com/1.0.x/admin-api/#show-upstream-health-for-node via targets resource

Also, see TODO notes at bottom of targets.go for info on additional methods that need to be implemented at some point.