### PR TITLE
Fix for missing plugin parameters

### DIFF
--- a/plugins.go
+++ b/plugins.go
@@ -11,9 +11,9 @@ type PluginClient struct {
 
 type PluginRequest struct {
 	Name       string                 `json:"name"`
-	ConsumerId *Id                    `json:"consumer,omitempty"`
-	ServiceId  *Id                    `json:"service,omitempty"`
-	RouteId    *Id                    `json:"route,omitempty"`
+	ConsumerId *Id                    `json:"consumer"`
+	ServiceId  *Id                    `json:"service"`
+	RouteId    *Id                    `json:"route"`
 	RunOn      string                 `json:"run_on,omitempty"`
 	Config     map[string]interface{} `json:"config,omitempty"`
 	Enabled    *bool                  `json:"enabled,omitempty"`


### PR DESCRIPTION
There is an issue in the Kong (Kong Enterprise 0.36-2 at least). When you update an existing plugin with exactly the same config but one of the optional parameters is missing (`route`, `service` or `consumer`)  Kong throws odd error message like (where the `tag` parameter is provided, but only `route` is missing):

```json
{
    "message": "schema violation (tags.1: required field missing)",
    "name": "schema violation",
    "fields": {
        "tags": [
            "required field missing"
        ]
    },
    "code": 2
}
```

I've already reported issue to the Kong Support and I hope they will fix it but for now it would be nice to have this working.