### PR TITLE
Fix `TestRoutes_CreateWithSourcesAndDestinations` - Kong version >= 1.2.0

### DIFF
--- a/routes_test.go
+++ b/routes_test.go
@@ -66,7 +66,7 @@ func TestRoutes_CreateWithSourcesAndDestinations(t *testing.T) {
 	assert.NotNil(t, createdService)
 
 	routeRequest := &RouteRequest{
-		Protocols:    StringSlice([]string{"tcp"}),
+		Protocols:    StringSlice([]string{"tls"}),
 		StripPath:    Bool(true),
 		PreserveHost: Bool(true),
 		Snis:         StringSlice([]string{"example.com"}),


### PR DESCRIPTION
Schema validation changes in Kong 1.2.0 result in this test failing as SNIs can only be applied to secure routes. Same issue as reported in https://github.com/kevholditch/terraform-provider-kong/issues/88