### PR TITLE
Fix - update on upstream healthcheck `int` settings not applied

### DIFF
--- a/upstreams.go
+++ b/upstreams.go
@@ -39,16 +39,16 @@ type UpstreamHealthCheckActive struct {
 
 type ActiveHealthy struct {
 	HttpStatuses []int `json:"http_statuses,omitempty"`
-	Interval     int   `json:"interval,omitempty"`
-	Successes    int   `json:"successes,omitempty"`
+	Interval     int   `json:"interval"`
+	Successes    int   `json:"successes"`
 }
 
 type ActiveUnhealthy struct {
-	HttpFailures int   `json:"http_failures,omitempty"`
+	HttpFailures int   `json:"http_failures"`
 	HttpStatuses []int `json:"http_statuses,omitempty"`
-	Interval     int   `json:"interval,omitempty"`
-	TcpFailures  int   `json:"tcp_failures,omitempty"`
-	Timeouts     int   `json:"timeouts,omitempty"`
+	Interval     int   `json:"interval"`
+	TcpFailures  int   `json:"tcp_failures"`
+	Timeouts     int   `json:"timeouts"`
 }
 
 type UpstreamHealthCheckPassive struct {
@@ -59,14 +59,14 @@ type UpstreamHealthCheckPassive struct {
 
 type PassiveHealthy struct {
 	HttpStatuses []int `json:"http_statuses,omitempty"`
-	Successes    int   `json:"successes,omitempty"`
+	Successes    int   `json:"successes"`
 }
 
 type PassiveUnhealthy struct {
-	HttpFailures int   `json:"http_failures,omitempty"`
+	HttpFailures int   `json:"http_failures"`
 	HttpStatuses []int `json:"http_statuses,omitempty"`
-	TcpFailures  int   `json:"tcp_failures,omitempty"`
-	Timeouts     int   `json:"timeouts,omitempty"`
+	TcpFailures  int   `json:"tcp_failures"`
+	Timeouts     int   `json:"timeouts"`
 }
 
 type Upstream struct {

--- a/upstreams_test.go
+++ b/upstreams_test.go
@@ -217,28 +217,28 @@ func Test_UpstreamsUpdateById(t *testing.T) {
 				HttpsSni:               nil,
 				Healthy: &ActiveHealthy{
 					HttpStatuses: []int{200, 302},
-					Interval:     0,
-					Successes:    0,
+					Interval:     10,
+					Successes:    10,
 				},
 				Unhealthy: &ActiveUnhealthy{
-					HttpFailures: 0,
+					HttpFailures: 10,
 					HttpStatuses: []int{429, 404, 500, 501, 502, 503, 504, 505},
-					Interval:     0,
-					TcpFailures:  0,
-					Timeouts:     0,
+					Interval:     10,
+					TcpFailures:  10,
+					Timeouts:     10,
 				},
 			},
 			Passive: &UpstreamHealthCheckPassive{
 				Type: "http",
 				Healthy: &PassiveHealthy{
 					HttpStatuses: []int{200, 201, 202, 203, 204, 205, 206, 207, 208, 226, 300, 301, 302, 303, 304, 305, 306, 307, 308},
-					Successes:    0,
+					Successes:    10,
 				},
 				Unhealthy: &PassiveUnhealthy{
-					HttpFailures: 0,
+					HttpFailures: 10,
 					HttpStatuses: []int{429, 500, 503},
-					TcpFailures:  0,
-					Timeouts:     0,
+					TcpFailures:  10,
+					Timeouts:     10,
 				},
 			},
 		},
@@ -251,6 +251,19 @@ func Test_UpstreamsUpdateById(t *testing.T) {
 	assert.Equal(t, 10, createdUpstream.Slots)
 
 	upstreamRequest.Slots = 11
+	// Turn off health checks to ensure we can update from active to inactive state
+	// "healthy" checks
+	upstreamRequest.HealthChecks.Active.Healthy.Interval = 0
+	upstreamRequest.HealthChecks.Active.Healthy.Successes = 0
+	upstreamRequest.HealthChecks.Passive.Healthy.Successes = 0
+	// "unhealthy" checks
+	upstreamRequest.HealthChecks.Active.Unhealthy.Interval = 0
+	upstreamRequest.HealthChecks.Active.Unhealthy.HttpFailures = 0
+	upstreamRequest.HealthChecks.Active.Unhealthy.TcpFailures = 0
+	upstreamRequest.HealthChecks.Active.Unhealthy.Timeouts = 0
+	upstreamRequest.HealthChecks.Passive.Unhealthy.HttpFailures = 0
+	upstreamRequest.HealthChecks.Passive.Unhealthy.TcpFailures = 0
+	upstreamRequest.HealthChecks.Passive.Unhealthy.Timeouts = 0
 
 	result, err := client.Upstreams().UpdateById(createdUpstream.Id, upstreamRequest)
 


### PR DESCRIPTION
Do not omit zero values when performing update as this would prevent settings from being applied.

Resolves #54.