### PR TITLE
Creating interfaces for Clients

### DIFF
--- a/certificates.go
+++ b/certificates.go
@@ -5,7 +5,15 @@ import (
 	"fmt"
 )
 
-type CertificateClient struct {
+type CertificateClient interface {
+	GetById(id string) (*Certificate, error)
+	Create(certificateRequest *CertificateRequest) (*Certificate, error)
+	DeleteById(id string) error
+	List() (*Certificates, error)
+	UpdateById(id string, certificateRequest *CertificateRequest) (*Certificate, error)
+}
+
+type certificateClient struct {
 	config *Config
 }
 
@@ -27,7 +35,7 @@ type Certificates struct {
 
 const CertificatesPath = "/certificates/"
 
-func (certificateClient *CertificateClient) GetById(id string) (*Certificate, error) {
+func (certificateClient *certificateClient) GetById(id string) (*Certificate, error) {
 
 	r, body, errs := newGet(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath+id).End()
 	if errs != nil {
@@ -51,7 +59,7 @@ func (certificateClient *CertificateClient) GetById(id string) (*Certificate, er
 	return certificate, nil
 }
 
-func (certificateClient *CertificateClient) Create(certificateRequest *CertificateRequest) (*Certificate, error) {
+func (certificateClient *certificateClient) Create(certificateRequest *CertificateRequest) (*Certificate, error) {
 
 	r, body, errs := newPost(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath).Send(certificateRequest).End()
 	if errs != nil {
@@ -75,7 +83,7 @@ func (certificateClient *CertificateClient) Create(certificateRequest *Certifica
 	return createdCertificate, nil
 }
 
-func (certificateClient *CertificateClient) DeleteById(id string) error {
+func (certificateClient *certificateClient) DeleteById(id string) error {
 
 	r, body, errs := newDelete(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath+id).End()
 	if errs != nil {
@@ -89,7 +97,7 @@ func (certificateClient *CertificateClient) DeleteById(id string) error {
 	return nil
 }
 
-func (certificateClient *CertificateClient) List() (*Certificates, error) {
+func (certificateClient *certificateClient) List() (*Certificates, error) {
 
 	r, body, errs := newGet(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath).End()
 	if errs != nil {
@@ -109,7 +117,7 @@ func (certificateClient *CertificateClient) List() (*Certificates, error) {
 	return certificates, nil
 }
 
-func (certificateClient *CertificateClient) UpdateById(id string, certificateRequest *CertificateRequest) (*Certificate, error) {
+func (certificateClient *certificateClient) UpdateById(id string, certificateRequest *CertificateRequest) (*Certificate, error) {
 
 	r, body, errs := newPatch(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath+id).Send(certificateRequest).End()
 	if errs != nil {

--- a/client.go
+++ b/client.go
@@ -17,7 +17,19 @@ const EnvKongTLSSkipVerify = "TLS_SKIP_VERIFY"
 const EnvKongApiKey = "KONG_API_KEY"
 const EnvKongAdminToken = "KONG_ADMIN_TOKEN"
 
-type KongAdminClient struct {
+type KongAdminClient interface {
+	Status() StatusClient
+	Consumers() ConsumerClient
+	Plugins() PluginClient
+	Certificates() CertificateClient
+	Snis() SnisClient
+	Upstreams() UpstreamClient
+	Routes() RouteClient
+	Services() ServiceClient
+	Targets() TargetClient
+}
+
+type kongAdminClient struct {
 	config *Config
 }
 
@@ -83,63 +95,62 @@ func NewDefaultConfig() *Config {
 	return config
 }
 
-func NewClient(config *Config) *KongAdminClient {
-	return &KongAdminClient{
+func NewClient(config *Config) *kongAdminClient {
+	return &kongAdminClient{
 		config: config,
 	}
 }
 
-func (kongAdminClient *KongAdminClient) Status() *StatusClient {
-	return &StatusClient{
-		config: kongAdminClient.config,
-	}
-
-}
-
-func (kongAdminClient *KongAdminClient) Consumers() *ConsumerClient {
-	return &ConsumerClient{
+func (kongAdminClient *kongAdminClient) Status() StatusClient {
+	return &statusClient{
 		config: kongAdminClient.config,
 	}
 }
 
-func (kongAdminClient *KongAdminClient) Plugins() *PluginClient {
-	return &PluginClient{
+func (kongAdminClient *kongAdminClient) Consumers() ConsumerClient {
+	return &consumerClient{
 		config: kongAdminClient.config,
 	}
 }
 
-func (kongAdminClient *KongAdminClient) Certificates() *CertificateClient {
-	return &CertificateClient{
+func (kongAdminClient *kongAdminClient) Plugins() PluginClient {
+	return &pluginClient{
 		config: kongAdminClient.config,
 	}
 }
 
-func (kongAdminClient *KongAdminClient) Snis() *SnisClient {
-	return &SnisClient{
+func (kongAdminClient *kongAdminClient) Certificates() CertificateClient {
+	return &certificateClient{
 		config: kongAdminClient.config,
 	}
 }
 
-func (kongAdminClient *KongAdminClient) Upstreams() *UpstreamClient {
-	return &UpstreamClient{
+func (kongAdminClient *kongAdminClient) Snis() SnisClient {
+	return &snisClient{
 		config: kongAdminClient.config,
 	}
 }
 
-func (kongAdminClient *KongAdminClient) Routes() *RouteClient {
-	return &RouteClient{
+func (kongAdminClient *kongAdminClient) Upstreams() UpstreamClient {
+	return &upstreamClient{
 		config: kongAdminClient.config,
 	}
 }
 
-func (kongAdminClient *KongAdminClient) Services() *ServiceClient {
-	return &ServiceClient{
+func (kongAdminClient *kongAdminClient) Routes() RouteClient {
+	return &routeClient{
 		config: kongAdminClient.config,
 	}
 }
 
-func (kongAdminClient *KongAdminClient) Targets() *TargetClient {
-	return &TargetClient{
+func (kongAdminClient *kongAdminClient) Services() ServiceClient {
+	return &serviceClient{
+		config: kongAdminClient.config,
+	}
+}
+
+func (kongAdminClient *kongAdminClient) Targets() TargetClient {
+	return &targetClient{
 		config: kongAdminClient.config,
 	}
 }

--- a/consumers.go
+++ b/consumers.go
@@ -5,7 +5,21 @@ import (
 	"fmt"
 )
 
-type ConsumerClient struct {
+type ConsumerClient interface {
+	GetByUsername(username string) (*Consumer, error)
+	GetById(id string) (*Consumer, error)
+	Create(consumerRequest *ConsumerRequest) (*Consumer, error)
+	List() (*Consumers, error)
+	DeleteByUsername(username string) error
+	DeleteById(id string) error
+	UpdateByUsername(username string, consumerRequest *ConsumerRequest) (*Consumer, error)
+	UpdateById(id string, consumerRequest *ConsumerRequest) (*Consumer, error)
+	CreatePluginConfig(consumerId string, pluginName string, pluginConfig string) (*ConsumerPluginConfig, error)
+	GetPluginConfig(consumerId string, pluginName string, id string) (*ConsumerPluginConfig, error)
+	DeletePluginConfig(consumerId string, pluginName string, id string) error
+}
+
+type consumerClient struct {
 	config *Config
 }
 
@@ -32,11 +46,11 @@ type ConsumerPluginConfig struct {
 
 const ConsumersPath = "/consumers/"
 
-func (consumerClient *ConsumerClient) GetByUsername(username string) (*Consumer, error) {
+func (consumerClient *consumerClient) GetByUsername(username string) (*Consumer, error) {
 	return consumerClient.GetById(username)
 }
 
-func (consumerClient *ConsumerClient) GetById(id string) (*Consumer, error) {
+func (consumerClient *consumerClient) GetById(id string) (*Consumer, error) {
 
 	r, body, errs := newGet(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+id).End()
 	if errs != nil {
@@ -60,7 +74,7 @@ func (consumerClient *ConsumerClient) GetById(id string) (*Consumer, error) {
 	return consumer, nil
 }
 
-func (consumerClient *ConsumerClient) Create(consumerRequest *ConsumerRequest) (*Consumer, error) {
+func (consumerClient *consumerClient) Create(consumerRequest *ConsumerRequest) (*Consumer, error) {
 
 	r, body, errs := newPost(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath).Send(consumerRequest).End()
 	if errs != nil {
@@ -84,7 +98,7 @@ func (consumerClient *ConsumerClient) Create(consumerRequest *ConsumerRequest) (
 	return createdConsumer, nil
 }
 
-func (consumerClient *ConsumerClient) List() (*Consumers, error) {
+func (consumerClient *consumerClient) List() (*Consumers, error) {
 
 	r, body, errs := newGet(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath).End()
 	if errs != nil {
@@ -104,11 +118,11 @@ func (consumerClient *ConsumerClient) List() (*Consumers, error) {
 	return consumers, nil
 }
 
-func (consumerClient *ConsumerClient) DeleteByUsername(username string) error {
+func (consumerClient *consumerClient) DeleteByUsername(username string) error {
 	return consumerClient.DeleteById(username)
 }
 
-func (consumerClient *ConsumerClient) DeleteById(id string) error {
+func (consumerClient *consumerClient) DeleteById(id string) error {
 
 	r, body, errs := newDelete(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+id).End()
 	if errs != nil {
@@ -122,11 +136,11 @@ func (consumerClient *ConsumerClient) DeleteById(id string) error {
 	return nil
 }
 
-func (consumerClient *ConsumerClient) UpdateByUsername(username string, consumerRequest *ConsumerRequest) (*Consumer, error) {
+func (consumerClient *consumerClient) UpdateByUsername(username string, consumerRequest *ConsumerRequest) (*Consumer, error) {
 	return consumerClient.UpdateById(username, consumerRequest)
 }
 
-func (consumerClient *ConsumerClient) UpdateById(id string, consumerRequest *ConsumerRequest) (*Consumer, error) {
+func (consumerClient *consumerClient) UpdateById(id string, consumerRequest *ConsumerRequest) (*Consumer, error) {
 
 	r, body, errs := newPatch(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+id).Send(consumerRequest).End()
 	if errs != nil {
@@ -150,7 +164,7 @@ func (consumerClient *ConsumerClient) UpdateById(id string, consumerRequest *Con
 	return updatedConsumer, nil
 }
 
-func (consumerClient *ConsumerClient) CreatePluginConfig(consumerId string, pluginName string, pluginConfig string) (*ConsumerPluginConfig, error) {
+func (consumerClient *consumerClient) CreatePluginConfig(consumerId string, pluginName string, pluginConfig string) (*ConsumerPluginConfig, error) {
 
 	r, body, errs := newPost(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName).Send(pluginConfig).End()
 	if errs != nil {
@@ -176,7 +190,7 @@ func (consumerClient *ConsumerClient) CreatePluginConfig(consumerId string, plug
 	return createdConsumerPluginConfig, nil
 }
 
-func (consumerClient *ConsumerClient) GetPluginConfig(consumerId string, pluginName string, id string) (*ConsumerPluginConfig, error) {
+func (consumerClient *consumerClient) GetPluginConfig(consumerId string, pluginName string, id string) (*ConsumerPluginConfig, error) {
 
 	r, body, errs := newGet(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName+"/"+id).End()
 	if errs != nil {
@@ -202,7 +216,7 @@ func (consumerClient *ConsumerClient) GetPluginConfig(consumerId string, pluginN
 	return consumerPluginConfig, nil
 }
 
-func (consumerClient *ConsumerClient) DeletePluginConfig(consumerId string, pluginName string, id string) error {
+func (consumerClient *consumerClient) DeletePluginConfig(consumerId string, pluginName string, id string) error {
 
 	r, body, errs := newDelete(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName+"/"+id).End()
 	if errs != nil {

--- a/plugins.go
+++ b/plugins.go
@@ -5,7 +5,18 @@ import (
 	"fmt"
 )
 
-type PluginClient struct {
+type PluginClient interface {
+	GetById(id string) (*Plugin, error)
+	List(query *PluginQueryString) ([]*Plugin, error)
+	Create(pluginRequest *PluginRequest) (*Plugin, error)
+	UpdateById(id string, pluginRequest *PluginRequest) (*Plugin, error)
+	DeleteById(id string) error
+	GetByConsumerId(id string) (*Plugins, error)
+	GetByRouteId(id string) (*Plugins, error)
+	GetByServiceId(id string) (*Plugins, error)
+}
+
+type pluginClient struct {
 	config *Config
 }
 
@@ -43,7 +54,7 @@ type PluginQueryString struct {
 
 const PluginsPath = "/plugins/"
 
-func (pluginClient *PluginClient) GetById(id string) (*Plugin, error) {
+func (pluginClient *pluginClient) GetById(id string) (*Plugin, error) {
 
 	r, body, errs := newGet(pluginClient.config, pluginClient.config.HostAddress+PluginsPath+id).End()
 	if errs != nil {
@@ -67,7 +78,7 @@ func (pluginClient *PluginClient) GetById(id string) (*Plugin, error) {
 	return plugin, nil
 }
 
-func (pluginClient *PluginClient) List(query *PluginQueryString) ([]*Plugin, error) {
+func (pluginClient *pluginClient) List(query *PluginQueryString) ([]*Plugin, error) {
 	plugins := make([]*Plugin, 0)
 
 	if query.Size < 100 {
@@ -107,7 +118,7 @@ func (pluginClient *PluginClient) List(query *PluginQueryString) ([]*Plugin, err
 	return plugins, nil
 }
 
-func (pluginClient *PluginClient) Create(pluginRequest *PluginRequest) (*Plugin, error) {
+func (pluginClient *pluginClient) Create(pluginRequest *PluginRequest) (*Plugin, error) {
 
 	r, body, errs := newPost(pluginClient.config, pluginClient.config.HostAddress+PluginsPath).Send(pluginRequest).End()
 	if errs != nil {
@@ -131,7 +142,7 @@ func (pluginClient *PluginClient) Create(pluginRequest *PluginRequest) (*Plugin,
 	return createdPlugin, nil
 }
 
-func (pluginClient *PluginClient) UpdateById(id string, pluginRequest *PluginRequest) (*Plugin, error) {
+func (pluginClient *pluginClient) UpdateById(id string, pluginRequest *PluginRequest) (*Plugin, error) {
 
 	r, body, errs := newPatch(pluginClient.config, pluginClient.config.HostAddress+PluginsPath+id).Send(pluginRequest).End()
 	if errs != nil {
@@ -155,7 +166,7 @@ func (pluginClient *PluginClient) UpdateById(id string, pluginRequest *PluginReq
 	return updatedPlugin, nil
 }
 
-func (pluginClient *PluginClient) DeleteById(id string) error {
+func (pluginClient *pluginClient) DeleteById(id string) error {
 
 	r, body, errs := newDelete(pluginClient.config, pluginClient.config.HostAddress+PluginsPath+id).End()
 	if errs != nil {
@@ -169,7 +180,7 @@ func (pluginClient *PluginClient) DeleteById(id string) error {
 	return nil
 }
 
-func (pluginClient *PluginClient) GetByConsumerId(id string) (*Plugins, error) {
+func (pluginClient *pluginClient) GetByConsumerId(id string) (*Plugins, error) {
 	r, body, errs := newGet(pluginClient.config, pluginClient.config.HostAddress+"/consumers/"+id+"/plugins").End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get plugins, error: %v", errs)
@@ -188,7 +199,7 @@ func (pluginClient *PluginClient) GetByConsumerId(id string) (*Plugins, error) {
 	return plugins, nil
 }
 
-func (pluginClient *PluginClient) GetByRouteId(id string) (*Plugins, error) {
+func (pluginClient *pluginClient) GetByRouteId(id string) (*Plugins, error) {
 	r, body, errs := newGet(pluginClient.config, pluginClient.config.HostAddress+"/routes/"+id+"/plugins").End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get plugins, error: %v", errs)
@@ -207,7 +218,7 @@ func (pluginClient *PluginClient) GetByRouteId(id string) (*Plugins, error) {
 	return plugins, nil
 }
 
-func (pluginClient *PluginClient) GetByServiceId(id string) (*Plugins, error) {
+func (pluginClient *pluginClient) GetByServiceId(id string) (*Plugins, error) {
 	r, body, errs := newGet(pluginClient.config, pluginClient.config.HostAddress+"/services/"+id+"/plugins").End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get plugins, error: %v", errs)

--- a/routes.go
+++ b/routes.go
@@ -5,7 +5,20 @@ import (
 	"fmt"
 )
 
-type RouteClient struct {
+type RouteClient interface {
+	GetByName(name string) (*Route, error)
+	GetById(id string) (*Route, error)
+	Create(routeRequest *RouteRequest) (*Route, error)
+	List(query *RouteQueryString) ([]*Route, error)
+	GetRoutesFromServiceName(name string) ([]*Route, error)
+	GetRoutesFromServiceId(id string) ([]*Route, error)
+	UpdateByName(name string, routeRequest *RouteRequest) (*Route, error)
+	UpdateById(id string, routeRequest *RouteRequest) (*Route, error)
+	DeleteByName(name string) error
+	DeleteById(id string) error
+}
+
+type routeClient struct {
 	config *Config
 }
 
@@ -60,11 +73,11 @@ type RouteQueryString struct {
 
 const RoutesPath = "/routes/"
 
-func (routeClient *RouteClient) GetByName(name string) (*Route, error) {
+func (routeClient *routeClient) GetByName(name string) (*Route, error) {
 	return routeClient.GetById(name)
 }
 
-func (routeClient *RouteClient) GetById(id string) (*Route, error) {
+func (routeClient *routeClient) GetById(id string) (*Route, error) {
 	r, body, errs := newGet(routeClient.config, routeClient.config.HostAddress+RoutesPath+id).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get the route, error: %v", errs)
@@ -87,7 +100,7 @@ func (routeClient *RouteClient) GetById(id string) (*Route, error) {
 	return route, nil
 }
 
-func (routeClient *RouteClient) Create(routeRequest *RouteRequest) (*Route, error) {
+func (routeClient *routeClient) Create(routeRequest *RouteRequest) (*Route, error) {
 	r, body, errs := newPost(routeClient.config, routeClient.config.HostAddress+RoutesPath).Send(routeRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not register the route, error: %v", errs)
@@ -110,7 +123,7 @@ func (routeClient *RouteClient) Create(routeRequest *RouteRequest) (*Route, erro
 	return createdRoute, nil
 }
 
-func (routeClient *RouteClient) List(query *RouteQueryString) ([]*Route, error) {
+func (routeClient *routeClient) List(query *RouteQueryString) ([]*Route, error) {
 	routes := make([]*Route, 0)
 
 	if query.Size < 100 {
@@ -150,11 +163,11 @@ func (routeClient *RouteClient) List(query *RouteQueryString) ([]*Route, error) 
 	return routes, nil
 }
 
-func (routeClient *RouteClient) GetRoutesFromServiceName(name string) ([]*Route, error) {
+func (routeClient *routeClient) GetRoutesFromServiceName(name string) ([]*Route, error) {
 	return routeClient.GetRoutesFromServiceId(name)
 }
 
-func (routeClient *RouteClient) GetRoutesFromServiceId(id string) ([]*Route, error) {
+func (routeClient *routeClient) GetRoutesFromServiceId(id string) ([]*Route, error) {
 	routes := make([]*Route, 0)
 	data := &Routes{}
 
@@ -183,11 +196,11 @@ func (routeClient *RouteClient) GetRoutesFromServiceId(id string) ([]*Route, err
 	return routes, nil
 }
 
-func (routeClient *RouteClient) UpdateByName(name string, routeRequest *RouteRequest) (*Route, error) {
+func (routeClient *routeClient) UpdateByName(name string, routeRequest *RouteRequest) (*Route, error) {
 	return routeClient.UpdateById(name, routeRequest)
 }
 
-func (routeClient *RouteClient) UpdateById(id string, routeRequest *RouteRequest) (*Route, error) {
+func (routeClient *routeClient) UpdateById(id string, routeRequest *RouteRequest) (*Route, error) {
 	r, body, errs := newPatch(routeClient.config, routeClient.config.HostAddress+RoutesPath+id).Send(routeRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update route, error: %v", errs)
@@ -210,11 +223,11 @@ func (routeClient *RouteClient) UpdateById(id string, routeRequest *RouteRequest
 	return updatedRoute, nil
 }
 
-func (routeClient *RouteClient) DeleteByName(name string) error {
+func (routeClient *routeClient) DeleteByName(name string) error {
 	return routeClient.DeleteById(name)
 }
 
-func (routeClient *RouteClient) DeleteById(id string) error {
+func (routeClient *routeClient) DeleteById(id string) error {
 	r, body, errs := newDelete(routeClient.config, routeClient.config.HostAddress+RoutesPath+id).End()
 	if errs != nil {
 		return fmt.Errorf("could not delete the route, result: %v error: %v", r, errs)

--- a/snis.go
+++ b/snis.go
@@ -5,7 +5,15 @@ import (
 	"fmt"
 )
 
-type SnisClient struct {
+type SnisClient interface {
+	Create(snisRequest *SnisRequest) (*Sni, error)
+	GetByName(name string) (*Sni, error)
+	List() (*Snis, error)
+	DeleteByName(name string) error
+	UpdateByName(name string, snisRequest *SnisRequest) (*Sni, error)
+}
+
+type snisClient struct {
 	config *Config
 }
 
@@ -26,7 +34,7 @@ type Snis struct {
 
 const SnisPath = "/snis/"
 
-func (snisClient *SnisClient) Create(snisRequest *SnisRequest) (*Sni, error) {
+func (snisClient *snisClient) Create(snisRequest *SnisRequest) (*Sni, error) {
 
 	r, body, errs := newPost(snisClient.config, snisClient.config.HostAddress+SnisPath).Send(snisRequest).End()
 	if errs != nil {
@@ -50,7 +58,7 @@ func (snisClient *SnisClient) Create(snisRequest *SnisRequest) (*Sni, error) {
 	return sni, nil
 }
 
-func (snisClient *SnisClient) GetByName(name string) (*Sni, error) {
+func (snisClient *snisClient) GetByName(name string) (*Sni, error) {
 
 	r, body, errs := newGet(snisClient.config, snisClient.config.HostAddress+SnisPath+name).End()
 	if errs != nil {
@@ -74,7 +82,7 @@ func (snisClient *SnisClient) GetByName(name string) (*Sni, error) {
 	return sni, nil
 }
 
-func (snisClient *SnisClient) List() (*Snis, error) {
+func (snisClient *snisClient) List() (*Snis, error) {
 
 	r, body, errs := newGet(snisClient.config, snisClient.config.HostAddress+SnisPath).End()
 	if errs != nil {
@@ -94,7 +102,7 @@ func (snisClient *SnisClient) List() (*Snis, error) {
 	return snis, nil
 }
 
-func (snisClient *SnisClient) DeleteByName(name string) error {
+func (snisClient *snisClient) DeleteByName(name string) error {
 
 	r, body, errs := newDelete(snisClient.config, snisClient.config.HostAddress+SnisPath+name).End()
 	if errs != nil {
@@ -108,7 +116,7 @@ func (snisClient *SnisClient) DeleteByName(name string) error {
 	return nil
 }
 
-func (snisClient *SnisClient) UpdateByName(name string, snisRequest *SnisRequest) (*Sni, error) {
+func (snisClient *snisClient) UpdateByName(name string, snisRequest *SnisRequest) (*Sni, error) {
 
 	r, body, errs := newPatch(snisClient.config, snisClient.config.HostAddress+SnisPath+name).Send(snisRequest).End()
 	if errs != nil {

--- a/status.go
+++ b/status.go
@@ -6,7 +6,11 @@ import (
 	"fmt"
 )
 
-type StatusClient struct {
+type StatusClient interface {
+	Get() (*Status, error)
+}
+
+type statusClient struct {
 	config *Config
 }
 
@@ -29,7 +33,7 @@ type databaseStatus struct {
 	Reachable bool `json:"reachable" yaml:"reachable"`
 }
 
-func (statusClient *StatusClient) Get() (*Status, error) {
+func (statusClient *statusClient) Get() (*Status, error) {
 
 	_, body, errs := newGet(statusClient.config, statusClient.config.HostAddress+"/status").End()
 	if errs != nil {

--- a/targets.go
+++ b/targets.go
@@ -5,7 +5,22 @@ import (
 	"fmt"
 )
 
-type TargetClient struct {
+type TargetClient interface {
+	CreateFromUpstreamName(name string, targetRequest *TargetRequest) (*Target, error)
+	CreateFromUpstreamId(id string, targetRequest *TargetRequest) (*Target, error)
+	GetTargetsFromUpstreamName(name string) ([]*Target, error)
+	GetTargetsFromUpstreamId(id string) ([]*Target, error)
+	DeleteFromUpstreamByHostPort(upstreamNameOrId string, hostPort string) error
+	DeleteFromUpstreamById(upstreamNameOrId string, id string) error
+	SetTargetFromUpstreamByHostPortAsHealthy(upstreamNameOrId string, hostPort string) error
+	SetTargetFromUpstreamByIdAsHealthy(upstreamNameOrId string, id string) error
+	SetTargetFromUpstreamByHostPortAsUnhealthy(upstreamNameOrId string, hostPort string) error
+	SetTargetFromUpstreamByIdAsUnhealthy(upstreamNameOrId string, id string) error
+	GetTargetsWithHealthFromUpstreamName(name string) ([]*Target, error)
+	GetTargetsWithHealthFromUpstreamId(id string) ([]*Target, error)
+}
+
+type targetClient struct {
 	config *Config
 }
 
@@ -32,11 +47,11 @@ type Targets struct {
 
 const TargetsPath = "/upstreams/%s/targets"
 
-func (targetClient *TargetClient) CreateFromUpstreamName(name string, targetRequest *TargetRequest) (*Target, error) {
+func (targetClient *targetClient) CreateFromUpstreamName(name string, targetRequest *TargetRequest) (*Target, error) {
 	return targetClient.CreateFromUpstreamId(name, targetRequest)
 }
 
-func (targetClient *TargetClient) CreateFromUpstreamId(id string, targetRequest *TargetRequest) (*Target, error) {
+func (targetClient *targetClient) CreateFromUpstreamId(id string, targetRequest *TargetRequest) (*Target, error) {
 	r, body, errs := newPost(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf(TargetsPath, id)).Send(targetRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not register the target, error: %v", errs)
@@ -59,11 +74,11 @@ func (targetClient *TargetClient) CreateFromUpstreamId(id string, targetRequest 
 	return createdTarget, nil
 }
 
-func (targetClient *TargetClient) GetTargetsFromUpstreamName(name string) ([]*Target, error) {
+func (targetClient *targetClient) GetTargetsFromUpstreamName(name string) ([]*Target, error) {
 	return targetClient.GetTargetsFromUpstreamId(name)
 }
 
-func (targetClient *TargetClient) GetTargetsFromUpstreamId(id string) ([]*Target, error) {
+func (targetClient *targetClient) GetTargetsFromUpstreamId(id string) ([]*Target, error) {
 	targets := []*Target{}
 	data := &Targets{}
 
@@ -95,11 +110,11 @@ func (targetClient *TargetClient) GetTargetsFromUpstreamId(id string) ([]*Target
 	return targets, nil
 }
 
-func (targetClient *TargetClient) DeleteFromUpstreamByHostPort(upstreamNameOrId string, hostPort string) error {
+func (targetClient *targetClient) DeleteFromUpstreamByHostPort(upstreamNameOrId string, hostPort string) error {
 	return targetClient.DeleteFromUpstreamById(upstreamNameOrId, hostPort)
 }
 
-func (targetClient *TargetClient) DeleteFromUpstreamById(upstreamNameOrId string, id string) error {
+func (targetClient *targetClient) DeleteFromUpstreamById(upstreamNameOrId string, id string) error {
 	r, body, errs := newDelete(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf(TargetsPath, upstreamNameOrId)+fmt.Sprintf("/%s", id)).End()
 	if errs != nil {
 		return fmt.Errorf("could not delete the target, result: %v error: %v", r, errs)
@@ -116,11 +131,11 @@ func (targetClient *TargetClient) DeleteFromUpstreamById(upstreamNameOrId string
 	return nil
 }
 
-func (targetClient *TargetClient) SetTargetFromUpstreamByHostPortAsHealthy(upstreamNameOrId string, hostPort string) error {
+func (targetClient *targetClient) SetTargetFromUpstreamByHostPortAsHealthy(upstreamNameOrId string, hostPort string) error {
 	return targetClient.SetTargetFromUpstreamByIdAsHealthy(upstreamNameOrId, hostPort)
 }
 
-func (targetClient *TargetClient) SetTargetFromUpstreamByIdAsHealthy(upstreamNameOrId string, id string) error {
+func (targetClient *targetClient) SetTargetFromUpstreamByIdAsHealthy(upstreamNameOrId string, id string) error {
 	r, body, errs := newPost(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf(TargetsPath, upstreamNameOrId)+fmt.Sprintf("/%s/healthy", id)).Send("").End()
 	if errs != nil {
 		return fmt.Errorf("could not set the target as healthy, result: %v error: %v", r, errs)
@@ -137,11 +152,11 @@ func (targetClient *TargetClient) SetTargetFromUpstreamByIdAsHealthy(upstreamNam
 	return nil
 }
 
-func (targetClient *TargetClient) SetTargetFromUpstreamByHostPortAsUnhealthy(upstreamNameOrId string, hostPort string) error {
+func (targetClient *targetClient) SetTargetFromUpstreamByHostPortAsUnhealthy(upstreamNameOrId string, hostPort string) error {
 	return targetClient.SetTargetFromUpstreamByIdAsUnhealthy(upstreamNameOrId, hostPort)
 }
 
-func (targetClient *TargetClient) SetTargetFromUpstreamByIdAsUnhealthy(upstreamNameOrId string, id string) error {
+func (targetClient *targetClient) SetTargetFromUpstreamByIdAsUnhealthy(upstreamNameOrId string, id string) error {
 	r, body, errs := newPost(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf(TargetsPath, upstreamNameOrId)+fmt.Sprintf("/%s/unhealthy", id)).Send("").End()
 	if errs != nil {
 		return fmt.Errorf("could not set the target as unhealthy, result: %v error: %v", r, errs)
@@ -158,11 +173,11 @@ func (targetClient *TargetClient) SetTargetFromUpstreamByIdAsUnhealthy(upstreamN
 	return nil
 }
 
-func (targetClient *TargetClient) GetTargetsWithHealthFromUpstreamName(name string) ([]*Target, error) {
+func (targetClient *targetClient) GetTargetsWithHealthFromUpstreamName(name string) ([]*Target, error) {
 	return targetClient.GetTargetsWithHealthFromUpstreamId(name)
 }
 
-func (targetClient *TargetClient) GetTargetsWithHealthFromUpstreamId(id string) ([]*Target, error) {
+func (targetClient *targetClient) GetTargetsWithHealthFromUpstreamId(id string) ([]*Target, error) {
 	targets := []*Target{}
 	data := &Targets{}
 

--- a/upstreams.go
+++ b/upstreams.go
@@ -5,7 +5,18 @@ import (
 	"fmt"
 )
 
-type UpstreamClient struct {
+type UpstreamClient interface {
+	GetByName(name string) (*Upstream, error)
+	GetById(id string) (*Upstream, error)
+	Create(upstreamRequest *UpstreamRequest) (*Upstream, error)
+	DeleteByName(name string) error
+	DeleteById(id string) error
+	List() (*Upstreams, error)
+	UpdateByName(name string, upstreamRequest *UpstreamRequest) (*Upstream, error)
+	UpdateById(id string, upstreamRequest *UpstreamRequest) (*Upstream, error)
+}
+
+type upstreamClient struct {
 	config *Config
 }
 
@@ -81,11 +92,11 @@ type Upstreams struct {
 
 const UpstreamsPath = "/upstreams/"
 
-func (upstreamClient *UpstreamClient) GetByName(name string) (*Upstream, error) {
+func (upstreamClient *upstreamClient) GetByName(name string) (*Upstream, error) {
 	return upstreamClient.GetById(name)
 }
 
-func (upstreamClient *UpstreamClient) GetById(id string) (*Upstream, error) {
+func (upstreamClient *upstreamClient) GetById(id string) (*Upstream, error) {
 
 	r, body, errs := newGet(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath+id).End()
 	if errs != nil {
@@ -109,7 +120,7 @@ func (upstreamClient *UpstreamClient) GetById(id string) (*Upstream, error) {
 	return upstream, nil
 }
 
-func (upstreamClient *UpstreamClient) Create(upstreamRequest *UpstreamRequest) (*Upstream, error) {
+func (upstreamClient *upstreamClient) Create(upstreamRequest *UpstreamRequest) (*Upstream, error) {
 
 	r, body, errs := newPost(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath).Send(upstreamRequest).End()
 	if errs != nil {
@@ -133,11 +144,11 @@ func (upstreamClient *UpstreamClient) Create(upstreamRequest *UpstreamRequest) (
 	return createdUpstream, nil
 }
 
-func (upstreamClient *UpstreamClient) DeleteByName(name string) error {
+func (upstreamClient *upstreamClient) DeleteByName(name string) error {
 	return upstreamClient.DeleteById(name)
 }
 
-func (upstreamClient *UpstreamClient) DeleteById(id string) error {
+func (upstreamClient *upstreamClient) DeleteById(id string) error {
 
 	r, body, errs := newDelete(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath+id).End()
 	if errs != nil {
@@ -151,7 +162,7 @@ func (upstreamClient *UpstreamClient) DeleteById(id string) error {
 	return nil
 }
 
-func (upstreamClient *UpstreamClient) List() (*Upstreams, error) {
+func (upstreamClient *upstreamClient) List() (*Upstreams, error) {
 
 	r, body, errs := newGet(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath).End()
 	if errs != nil {
@@ -171,11 +182,11 @@ func (upstreamClient *UpstreamClient) List() (*Upstreams, error) {
 	return upstreams, nil
 }
 
-func (upstreamClient *UpstreamClient) UpdateByName(name string, upstreamRequest *UpstreamRequest) (*Upstream, error) {
+func (upstreamClient *upstreamClient) UpdateByName(name string, upstreamRequest *UpstreamRequest) (*Upstream, error) {
 	return upstreamClient.UpdateById(name, upstreamRequest)
 }
 
-func (upstreamClient *UpstreamClient) UpdateById(id string, upstreamRequest *UpstreamRequest) (*Upstream, error) {
+func (upstreamClient *upstreamClient) UpdateById(id string, upstreamRequest *UpstreamRequest) (*Upstream, error) {
 
 	r, body, errs := newPatch(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath+id).Send(upstreamRequest).End()
 	if errs != nil {


### PR DESCRIPTION
In order to allow us to mock the clients as we please to be able to
write better tests, we're creating a more abstract layer over the client
structs, having the contracts interfaced instead of directly
implemented.

As mentioned above, this should make the code a bit less coupled as well
as allow us for more thorough testing using Mocks.