### PR TITLE
Return an error when DeleteServiceById gets a 400

### DIFF
--- a/services.go
+++ b/services.go
@@ -215,6 +215,10 @@ func (serviceClient *ServiceClient) DeleteServiceById(id string) error {
 		return fmt.Errorf("could not delete the service, result: %v error: %v", r, errs)
 	}
 
+	if r.StatusCode == 400 {
+		return fmt.Errorf("bad request, message from kong: %s", body)
+	}
+
 	if r.StatusCode == 401 || r.StatusCode == 403 {
 		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}


### PR DESCRIPTION
There are some scenarios where Kong responds with a "Bad Request (400)"
error when trying to delete a service.

A good example is when given service
has at least 1 Route attached to it, and Kong will neither cascade the
delete to the Route nor allow us to delete the service, leving an
orphan Route behind