### PR TITLE
Kong EE's workspaces support & support for running tests with custom Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,13 @@ build: fmtcheck errcheck vet
 	go install
 
 test: goimportscheck
-	go test -v ./...
+	go test -v --tags="community" ./...
+
+test-all: goimportscheck
+	go test -v --tags="all" ./...
+
+test-enterprise: goimportscheck
+	go test -v --tags="enterprise" ./...
 
 vet:
 	@echo "go vet ."

--- a/api_key_test.go
+++ b/api_key_test.go
@@ -1,3 +1,5 @@
+// +build all community
+
 package gokong
 
 import (

--- a/certificates.go
+++ b/certificates.go
@@ -28,8 +28,7 @@ type Certificates struct {
 const CertificatesPath = "/certificates/"
 
 func (certificateClient *CertificateClient) GetById(id string) (*Certificate, error) {
-
-	r, body, errs := newGet(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath+id).End()
+	r, body, errs := newGet(certificateClient.config, CertificatesPath+id).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get certificate, error: %v", errs)
 	}
@@ -52,8 +51,7 @@ func (certificateClient *CertificateClient) GetById(id string) (*Certificate, er
 }
 
 func (certificateClient *CertificateClient) Create(certificateRequest *CertificateRequest) (*Certificate, error) {
-
-	r, body, errs := newPost(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath).Send(certificateRequest).End()
+	r, body, errs := newPost(certificateClient.config, CertificatesPath).Send(certificateRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not create new certificate, error: %v", errs)
 	}
@@ -76,8 +74,7 @@ func (certificateClient *CertificateClient) Create(certificateRequest *Certifica
 }
 
 func (certificateClient *CertificateClient) DeleteById(id string) error {
-
-	r, body, errs := newDelete(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath+id).End()
+	r, body, errs := newDelete(certificateClient.config, CertificatesPath+id).End()
 	if errs != nil {
 		return fmt.Errorf("could not delete certificate, result: %v error: %v", r, errs)
 	}
@@ -90,8 +87,7 @@ func (certificateClient *CertificateClient) DeleteById(id string) error {
 }
 
 func (certificateClient *CertificateClient) List() (*Certificates, error) {
-
-	r, body, errs := newGet(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath).End()
+	r, body, errs := newGet(certificateClient.config, CertificatesPath).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get certificates, error: %v", errs)
 	}
@@ -110,8 +106,7 @@ func (certificateClient *CertificateClient) List() (*Certificates, error) {
 }
 
 func (certificateClient *CertificateClient) UpdateById(id string, certificateRequest *CertificateRequest) (*Certificate, error) {
-
-	r, body, errs := newPatch(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath+id).Send(certificateRequest).End()
+	r, body, errs := newPatch(certificateClient.config, CertificatesPath+id).Send(certificateRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update certificate, error: %v", errs)
 	}

--- a/certificates_data_test.go
+++ b/certificates_data_test.go
@@ -1,3 +1,5 @@
+// +build all community
+
 package gokong
 
 const (

--- a/certificates_test.go
+++ b/certificates_test.go
@@ -1,3 +1,5 @@
+// +build all community
+
 package gokong
 
 import (

--- a/client.go
+++ b/client.go
@@ -16,6 +16,7 @@ const EnvKongAdminPassword = "KONG_ADMIN_PASSWORD"
 const EnvKongTLSSkipVerify = "TLS_SKIP_VERIFY"
 const EnvKongApiKey = "KONG_API_KEY"
 const EnvKongAdminToken = "KONG_ADMIN_TOKEN"
+const EnvKongWorkspace = "KONG_ADMIN_WORKSPACE"
 
 type KongAdminClient struct {
 	config *Config
@@ -28,6 +29,7 @@ type Config struct {
 	InsecureSkipVerify bool
 	ApiKey             string
 	AdminToken         string
+	Workspace          string
 }
 
 func addQueryString(currentUrl string, filter interface{}) (string, error) {
@@ -56,6 +58,7 @@ func NewDefaultConfig() *Config {
 		Username:           "",
 		Password:           "",
 		InsecureSkipVerify: false,
+		Workspace:          "",
 	}
 
 	if os.Getenv(EnvKongAdminHostAddress) != "" {
@@ -79,6 +82,9 @@ func NewDefaultConfig() *Config {
 	if os.Getenv(EnvKongAdminToken) != "" {
 		config.AdminToken = os.Getenv(EnvKongAdminToken)
 	}
+	if os.Getenv(EnvKongWorkspace) != "" {
+		config.Workspace = os.Getenv(EnvKongWorkspace)
+	}
 
 	return config
 }
@@ -93,7 +99,6 @@ func (kongAdminClient *KongAdminClient) Status() *StatusClient {
 	return &StatusClient{
 		config: kongAdminClient.config,
 	}
-
 }
 
 func (kongAdminClient *KongAdminClient) Consumers() *ConsumerClient {
@@ -140,6 +145,12 @@ func (kongAdminClient *KongAdminClient) Services() *ServiceClient {
 
 func (kongAdminClient *KongAdminClient) Targets() *TargetClient {
 	return &TargetClient{
+		config: kongAdminClient.config,
+	}
+}
+
+func (kongAdminClient *KongAdminClient) Workspaces() *WorkspaceClient {
+	return &WorkspaceClient{
 		config: kongAdminClient.config,
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,3 +1,5 @@
+// +build all community enterprise
+
 package gokong
 
 import (
@@ -15,6 +17,7 @@ import (
 )
 
 const defaultKongVersion = "1.0.2"
+const defaultDockerfilePath = ""
 const kong401Server = "KONG_401_SERVER"
 
 func Test_Newclient(t *testing.T) {
@@ -27,8 +30,10 @@ func Test_Newclient(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-
-	testContext := containers.StartKong(GetEnvVarOrDefault("KONG_VERSION", defaultKongVersion))
+	testContext := containers.StartKong(
+		GetEnvVarOrDefault("KONG_VERSION", defaultKongVersion),
+		GetEnvVarOrDefault("KONG_DOCKERFILE_PATH", defaultDockerfilePath),
+	)
 
 	err := os.Setenv(EnvKongAdminHostAddress, testContext.KongHostAddress)
 	if err != nil {
@@ -50,7 +55,6 @@ func TestMain(m *testing.M) {
 	containers.StopKong(testContext)
 
 	os.Exit(code)
-
 }
 
 type serveHttp struct {

--- a/consumers.go
+++ b/consumers.go
@@ -21,13 +21,25 @@ type Consumer struct {
 }
 
 type Consumers struct {
-	Results []*Consumer `json:"data,omitempty" yaml:"data,omitempty"`
-	Next    string      `json:"next,omitempty" yaml:"next,omitempty"`
+	Data   []*Consumer `json:"data,omitempty" yaml:"data,omitempty"`
+	Next   string      `json:"next,omitempty" yaml:"next,omitempty"`
+	Offset string      `json:"offset,omitempty" yaml:"offset,omitempty"`
+}
+
+type ConsumerQueryString struct {
+	Offset string `json:"offset,omitempty"`
+	Size   int    `json:"size"`
 }
 
 type ConsumerPluginConfig struct {
 	Id   string `json:"id,omitempty" yaml:"id,omitempty"`
 	Body string
+}
+
+type ConsumerPluginConfigs struct {
+	Data   []map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+	Next   string                   `json:"next,omitempty" yaml:"next,omitempty"`
+	Offset string                   `json:"offset,omitempty" yaml:"offset,omitempty"`
 }
 
 const ConsumersPath = "/consumers/"
@@ -37,8 +49,7 @@ func (consumerClient *ConsumerClient) GetByUsername(username string) (*Consumer,
 }
 
 func (consumerClient *ConsumerClient) GetById(id string) (*Consumer, error) {
-
-	r, body, errs := newGet(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+id).End()
+	r, body, errs := newGet(consumerClient.config, ConsumersPath+id).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get consumer, error: %v", errs)
 	}
@@ -61,8 +72,7 @@ func (consumerClient *ConsumerClient) GetById(id string) (*Consumer, error) {
 }
 
 func (consumerClient *ConsumerClient) Create(consumerRequest *ConsumerRequest) (*Consumer, error) {
-
-	r, body, errs := newPost(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath).Send(consumerRequest).End()
+	r, body, errs := newPost(consumerClient.config, ConsumersPath).Send(consumerRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not create new consumer, error: %v", errs)
 	}
@@ -84,21 +94,40 @@ func (consumerClient *ConsumerClient) Create(consumerRequest *ConsumerRequest) (
 	return createdConsumer, nil
 }
 
-func (consumerClient *ConsumerClient) List() (*Consumers, error) {
+func (consumerClient *ConsumerClient) List(query *ConsumerQueryString) ([]*Consumer, error) {
+	consumers := make([]*Consumer, 0)
 
-	r, body, errs := newGet(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath).End()
-	if errs != nil {
-		return nil, fmt.Errorf("could not get consumers, error: %v", errs)
+	if query.Size < 100 {
+		query.Size = 100
 	}
 
-	if r.StatusCode == 401 || r.StatusCode == 403 {
-		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	if query.Size > 1000 {
+		query.Size = 1000
 	}
 
-	consumers := &Consumers{}
-	err := json.Unmarshal([]byte(body), consumers)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse consumers list response, error: %v", err)
+	for {
+		data := &Consumers{}
+
+		r, body, errs := newGet(consumerClient.config, ConsumersPath).Query(*query).End()
+		if errs != nil {
+			return nil, fmt.Errorf("could not get the consumer, error: %v", errs)
+		}
+
+		if r.StatusCode == 401 || r.StatusCode == 403 {
+			return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+		}
+
+		err := json.Unmarshal([]byte(body), data)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse consumer get response, error: %v", err)
+		}
+
+		consumers = append(consumers, data.Data...)
+		if data.Next == "" {
+			break
+		}
+
+		query.Offset = data.Offset
 	}
 
 	return consumers, nil
@@ -109,8 +138,7 @@ func (consumerClient *ConsumerClient) DeleteByUsername(username string) error {
 }
 
 func (consumerClient *ConsumerClient) DeleteById(id string) error {
-
-	r, body, errs := newDelete(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+id).End()
+	r, body, errs := newDelete(consumerClient.config, ConsumersPath+id).End()
 	if errs != nil {
 		return fmt.Errorf("could not delete consumer, result: %v error: %v", r, errs)
 	}
@@ -127,8 +155,7 @@ func (consumerClient *ConsumerClient) UpdateByUsername(username string, consumer
 }
 
 func (consumerClient *ConsumerClient) UpdateById(id string, consumerRequest *ConsumerRequest) (*Consumer, error) {
-
-	r, body, errs := newPatch(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+id).Send(consumerRequest).End()
+	r, body, errs := newPatch(consumerClient.config, ConsumersPath+id).Send(consumerRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update consumer, error: %v", errs)
 	}
@@ -151,8 +178,7 @@ func (consumerClient *ConsumerClient) UpdateById(id string, consumerRequest *Con
 }
 
 func (consumerClient *ConsumerClient) CreatePluginConfig(consumerId string, pluginName string, pluginConfig string) (*ConsumerPluginConfig, error) {
-
-	r, body, errs := newPost(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName).Send(pluginConfig).End()
+	r, body, errs := newPost(consumerClient.config, ConsumersPath+consumerId+"/"+pluginName).Send(pluginConfig).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not configure plugin for consumer, error: %v", errs)
 	}
@@ -177,8 +203,7 @@ func (consumerClient *ConsumerClient) CreatePluginConfig(consumerId string, plug
 }
 
 func (consumerClient *ConsumerClient) GetPluginConfig(consumerId string, pluginName string, id string) (*ConsumerPluginConfig, error) {
-
-	r, body, errs := newGet(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName+"/"+id).End()
+	r, body, errs := newGet(consumerClient.config, ConsumersPath+consumerId+"/"+pluginName+"/"+id).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get plugin config for consumer, error: %v", errs)
 	}
@@ -202,9 +227,30 @@ func (consumerClient *ConsumerClient) GetPluginConfig(consumerId string, pluginN
 	return consumerPluginConfig, nil
 }
 
-func (consumerClient *ConsumerClient) DeletePluginConfig(consumerId string, pluginName string, id string) error {
+func (consumerClient *ConsumerClient) GetPluginConfigs(consumerId string, pluginName string) ([]map[string]interface{}, error) {
+	r, body, errs := newGet(consumerClient.config, ConsumersPath+consumerId+"/"+pluginName).End()
+	if errs != nil {
+		return nil, fmt.Errorf("could not get plugin config for consumer, error: %v", errs)
+	}
 
-	r, body, errs := newDelete(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName+"/"+id).End()
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	consumerPluginConfigs := &ConsumerPluginConfigs{}
+	err := json.Unmarshal([]byte(body), consumerPluginConfigs)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse consumer plugin config response, error: %v", err)
+	}
+	if len(consumerPluginConfigs.Data) == 0 {
+		return nil, nil
+	}
+
+	return consumerPluginConfigs.Data, nil
+}
+
+func (consumerClient *ConsumerClient) DeletePluginConfig(consumerId string, pluginName string, id string) error {
+	r, body, errs := newDelete(consumerClient.config, ConsumersPath+consumerId+"/"+pluginName+"/"+id).End()
 	if errs != nil {
 		return fmt.Errorf("could not delete plugin config for consumer, error: %v", errs)
 	}

--- a/consumers_test.go
+++ b/consumers_test.go
@@ -1,3 +1,5 @@
+// +build all community
+
 package gokong
 
 import (

--- a/containers/kong_container.go
+++ b/containers/kong_container.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/ory/dockertest"
+	uuid "github.com/satori/go.uuid"
 )
 
 type kongContainer struct {
@@ -16,8 +17,65 @@ type kongContainer struct {
 	HostAddress string
 }
 
-func NewKongContainer(pool *dockertest.Pool, postgres *postgresContainer, kongVersion string) *kongContainer {
+func NewKongContainerDockerfile(pool *dockertest.Pool, postgres *postgresContainer, dockerfilePath string) *kongContainer {
+	envVars := []string{
+		"KONG_DATABASE=postgres",
+		"KONG_ADMIN_LISTEN=0.0.0.0:8001",
+		fmt.Sprintf("KONG_PG_HOST=%s", postgres.Name),
+		fmt.Sprintf("KONG_PG_USER=%s", postgres.DatabaseUser),
+		fmt.Sprintf("KONG_PG_PASSWORD=%s", postgres.Password),
+		"KONG_PROXY_ACCESS_LOG=/dev/stdout",
+		"KONG_PROXY_ERROR_LOG=/dev/stderr",
+		"KONG_ADMIN_ACCESS_LOG=/dev/stdout",
+		"KONG_ADMIN_ERROR_LOG=/dev/stderr",
+	}
 
+	runOptions := &dockertest.RunOptions{
+		Name:  fmt.Sprintf("gokong-kong-tests-%s", uuid.NewV4().String()),
+		Env:   envVars,
+		Links: []string{fmt.Sprintf("%s:postgres", postgres.Name)},
+	}
+
+	resource, err := pool.BuildAndRunWithOptions(dockerfilePath, runOptions)
+	if err != nil {
+		log.Fatalf("Could not start resource: %s", err)
+	}
+
+	kongContainerName := getContainerName(resource)
+	kongAddress := fmt.Sprintf("http://localhost:%v", resource.GetPort("8001/tcp"))
+
+	if err := pool.Retry(func() error {
+		var err error
+		statusEndpoint := fmt.Sprintf("%s/status", kongAddress)
+		if err != nil {
+			return err
+		}
+
+		resp, err := http.Get(statusEndpoint)
+		if err != nil {
+			return err
+		}
+
+		if resp.StatusCode >= 400 {
+			return errors.New(fmt.Sprintf("Kong not ready: %+v", resp))
+		}
+
+		log.Printf("Kong (%v): up", kongContainerName)
+
+		return nil
+	}); err != nil {
+		log.Fatalf("Could not connect to kong: %s", err)
+	}
+
+	return &kongContainer{
+		Name:        kongContainerName,
+		pool:        pool,
+		resource:    resource,
+		HostAddress: kongAddress,
+	}
+}
+
+func NewKongContainer(pool *dockertest.Pool, postgres *postgresContainer, kongVersion string) *kongContainer {
 	envVars := []string{
 		"KONG_DATABASE=postgres",
 		"KONG_ADMIN_LISTEN=0.0.0.0:8001",

--- a/containers/testing.go
+++ b/containers/testing.go
@@ -12,7 +12,7 @@ type TestContext struct {
 	KongHostAddress string
 }
 
-func StartKong(kongVersion string) *TestContext {
+func StartKong(kongVersion, dockerfilePath string) *TestContext {
 	log.SetOutput(os.Stdout)
 
 	var err error
@@ -22,7 +22,13 @@ func StartKong(kongVersion string) *TestContext {
 	}
 
 	postgres := NewPostgresContainer(pool)
-	kong := NewKongContainer(pool, postgres, kongVersion)
+
+	var kong *kongContainer
+	if dockerfilePath == "" {
+		kong = NewKongContainer(pool, postgres, kongVersion)
+	} else {
+		kong = NewKongContainerDockerfile(pool, postgres, dockerfilePath)
+	}
 
 	return &TestContext{containers: []container{postgres, kong}, KongHostAddress: kong.HostAddress}
 }
@@ -35,5 +41,4 @@ func StopKong(testContext *TestContext) {
 			log.Printf("Could not stop container: %v \n", err)
 		}
 	}
-
 }

--- a/plugins.go
+++ b/plugins.go
@@ -45,7 +45,7 @@ const PluginsPath = "/plugins/"
 
 func (pluginClient *PluginClient) GetById(id string) (*Plugin, error) {
 
-	r, body, errs := newGet(pluginClient.config, pluginClient.config.HostAddress+PluginsPath+id).End()
+	r, body, errs := newGet(pluginClient.config, PluginsPath+id).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get plugin, error: %v", errs)
 	}
@@ -81,7 +81,7 @@ func (pluginClient *PluginClient) List(query *PluginQueryString) ([]*Plugin, err
 	for {
 		data := &Plugins{}
 
-		r, body, errs := newGet(pluginClient.config, pluginClient.config.HostAddress+PluginsPath).Query(*query).End()
+		r, body, errs := newGet(pluginClient.config, PluginsPath).Query(*query).End()
 		if errs != nil {
 			return nil, fmt.Errorf("could not get plugins, error: %v", errs)
 		}
@@ -108,8 +108,7 @@ func (pluginClient *PluginClient) List(query *PluginQueryString) ([]*Plugin, err
 }
 
 func (pluginClient *PluginClient) Create(pluginRequest *PluginRequest) (*Plugin, error) {
-
-	r, body, errs := newPost(pluginClient.config, pluginClient.config.HostAddress+PluginsPath).Send(pluginRequest).End()
+	r, body, errs := newPost(pluginClient.config, PluginsPath).Send(pluginRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not create new plugin, error: %v", errs)
 	}
@@ -132,8 +131,7 @@ func (pluginClient *PluginClient) Create(pluginRequest *PluginRequest) (*Plugin,
 }
 
 func (pluginClient *PluginClient) UpdateById(id string, pluginRequest *PluginRequest) (*Plugin, error) {
-
-	r, body, errs := newPatch(pluginClient.config, pluginClient.config.HostAddress+PluginsPath+id).Send(pluginRequest).End()
+	r, body, errs := newPatch(pluginClient.config, PluginsPath+id).Send(pluginRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update plugin, error: %v", errs)
 	}
@@ -156,8 +154,7 @@ func (pluginClient *PluginClient) UpdateById(id string, pluginRequest *PluginReq
 }
 
 func (pluginClient *PluginClient) DeleteById(id string) error {
-
-	r, body, errs := newDelete(pluginClient.config, pluginClient.config.HostAddress+PluginsPath+id).End()
+	r, body, errs := newDelete(pluginClient.config, PluginsPath+id).End()
 	if errs != nil {
 		return fmt.Errorf("could not delete plugin, result: %v error: %v", r, errs)
 	}
@@ -170,7 +167,7 @@ func (pluginClient *PluginClient) DeleteById(id string) error {
 }
 
 func (pluginClient *PluginClient) GetByConsumerId(id string) (*Plugins, error) {
-	r, body, errs := newGet(pluginClient.config, pluginClient.config.HostAddress+"/consumers/"+id+"/plugins").End()
+	r, body, errs := newGet(pluginClient.config, "/consumers/"+id+"/plugins").End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get plugins, error: %v", errs)
 	}
@@ -189,7 +186,7 @@ func (pluginClient *PluginClient) GetByConsumerId(id string) (*Plugins, error) {
 }
 
 func (pluginClient *PluginClient) GetByRouteId(id string) (*Plugins, error) {
-	r, body, errs := newGet(pluginClient.config, pluginClient.config.HostAddress+"/routes/"+id+"/plugins").End()
+	r, body, errs := newGet(pluginClient.config, "/routes/"+id+"/plugins").End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get plugins, error: %v", errs)
 	}
@@ -208,7 +205,7 @@ func (pluginClient *PluginClient) GetByRouteId(id string) (*Plugins, error) {
 }
 
 func (pluginClient *PluginClient) GetByServiceId(id string) (*Plugins, error) {
-	r, body, errs := newGet(pluginClient.config, pluginClient.config.HostAddress+"/services/"+id+"/plugins").End()
+	r, body, errs := newGet(pluginClient.config, "/services/"+id+"/plugins").End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get plugins, error: %v", errs)
 	}

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -1,3 +1,5 @@
+// +build all community
+
 package gokong
 
 import (

--- a/request.go
+++ b/request.go
@@ -2,6 +2,7 @@ package gokong
 
 import (
 	"crypto/tls"
+	"fmt"
 
 	"github.com/parnurzeal/gorequest"
 )
@@ -23,22 +24,49 @@ func configureRequest(r *gorequest.SuperAgent, config *Config) *gorequest.SuperA
 	return r
 }
 
-func newGet(config *Config, address string) *gorequest.SuperAgent {
+func buildRequestUri(config *Config, path string) string {
+	if config.Workspace == "" {
+		return config.HostAddress + path
+	}
+	return fmt.Sprintf("%s/%s%s", config.HostAddress, config.Workspace, path)
+}
+
+func newRawGet(config *Config, address string) *gorequest.SuperAgent {
 	r := gorequest.New().Get(address)
 	return configureRequest(r, config)
 }
 
-func newPost(config *Config, address string) *gorequest.SuperAgent {
+func newRawPost(config *Config, address string) *gorequest.SuperAgent {
 	r := gorequest.New().Post(address)
 	return configureRequest(r, config)
 }
 
-func newPatch(config *Config, address string) *gorequest.SuperAgent {
+func newRawPatch(config *Config, address string) *gorequest.SuperAgent {
 	r := gorequest.New().Patch(address)
 	return configureRequest(r, config)
 }
 
-func newDelete(config *Config, address string) *gorequest.SuperAgent {
+func newRawDelete(config *Config, address string) *gorequest.SuperAgent {
 	r := gorequest.New().Delete(address)
+	return configureRequest(r, config)
+}
+
+func newGet(config *Config, path string) *gorequest.SuperAgent {
+	r := gorequest.New().Get(buildRequestUri(config, path))
+	return configureRequest(r, config)
+}
+
+func newPost(config *Config, path string) *gorequest.SuperAgent {
+	r := gorequest.New().Post(buildRequestUri(config, path))
+	return configureRequest(r, config)
+}
+
+func newPatch(config *Config, path string) *gorequest.SuperAgent {
+	r := gorequest.New().Patch(buildRequestUri(config, path))
+	return configureRequest(r, config)
+}
+
+func newDelete(config *Config, path string) *gorequest.SuperAgent {
+	r := gorequest.New().Delete(buildRequestUri(config, path))
 	return configureRequest(r, config)
 }

--- a/routes.go
+++ b/routes.go
@@ -65,7 +65,7 @@ func (routeClient *RouteClient) GetByName(name string) (*Route, error) {
 }
 
 func (routeClient *RouteClient) GetById(id string) (*Route, error) {
-	r, body, errs := newGet(routeClient.config, routeClient.config.HostAddress+RoutesPath+id).End()
+	r, body, errs := newGet(routeClient.config, RoutesPath+id).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get the route, error: %v", errs)
 	}
@@ -88,7 +88,7 @@ func (routeClient *RouteClient) GetById(id string) (*Route, error) {
 }
 
 func (routeClient *RouteClient) Create(routeRequest *RouteRequest) (*Route, error) {
-	r, body, errs := newPost(routeClient.config, routeClient.config.HostAddress+RoutesPath).Send(routeRequest).End()
+	r, body, errs := newPost(routeClient.config, RoutesPath).Send(routeRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not register the route, error: %v", errs)
 	}
@@ -124,7 +124,7 @@ func (routeClient *RouteClient) List(query *RouteQueryString) ([]*Route, error) 
 	for {
 		data := &Routes{}
 
-		r, body, errs := newGet(routeClient.config, routeClient.config.HostAddress+RoutesPath).Query(*query).End()
+		r, body, errs := newGet(routeClient.config, RoutesPath).Query(*query).End()
 		if errs != nil {
 			return nil, fmt.Errorf("could not get the route, error: %v", errs)
 		}
@@ -159,7 +159,7 @@ func (routeClient *RouteClient) GetRoutesFromServiceId(id string) ([]*Route, err
 	data := &Routes{}
 
 	for {
-		r, body, errs := newGet(routeClient.config, routeClient.config.HostAddress+fmt.Sprintf("/services/%s/routes", id)).End()
+		r, body, errs := newGet(routeClient.config, fmt.Sprintf("/services/%s/routes", id)).End()
 		if errs != nil {
 			return nil, fmt.Errorf("could not get the route, error: %v", errs)
 		}
@@ -188,7 +188,7 @@ func (routeClient *RouteClient) UpdateByName(name string, routeRequest *RouteReq
 }
 
 func (routeClient *RouteClient) UpdateById(id string, routeRequest *RouteRequest) (*Route, error) {
-	r, body, errs := newPatch(routeClient.config, routeClient.config.HostAddress+RoutesPath+id).Send(routeRequest).End()
+	r, body, errs := newPatch(routeClient.config, RoutesPath+id).Send(routeRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update route, error: %v", errs)
 	}
@@ -215,7 +215,7 @@ func (routeClient *RouteClient) DeleteByName(name string) error {
 }
 
 func (routeClient *RouteClient) DeleteById(id string) error {
-	r, body, errs := newDelete(routeClient.config, routeClient.config.HostAddress+RoutesPath+id).End()
+	r, body, errs := newDelete(routeClient.config, RoutesPath+id).End()
 	if errs != nil {
 		return fmt.Errorf("could not delete the route, result: %v error: %v", r, errs)
 	}

--- a/routes_test.go
+++ b/routes_test.go
@@ -1,3 +1,5 @@
+// +build all community
+
 package gokong
 
 import (

--- a/services_test.go
+++ b/services_test.go
@@ -1,3 +1,5 @@
+// +build all community
+
 package gokong
 
 import (

--- a/services_test.go
+++ b/services_test.go
@@ -96,7 +96,6 @@ func TestServiceClient_UpdateServiceById(t *testing.T) {
 }
 
 func Test_ServicesGetNonExistentById(t *testing.T) {
-
 	service, err := NewClient(NewDefaultConfig()).Services().GetServiceById(uuid.NewV4().String())
 
 	assert.Nil(t, service)
@@ -104,7 +103,6 @@ func Test_ServicesGetNonExistentById(t *testing.T) {
 }
 
 func Test_ServicesGetNonExistentByName(t *testing.T) {
-
 	service, err := NewClient(NewDefaultConfig()).Services().GetServiceByName(uuid.NewV4().String())
 
 	assert.Nil(t, service)
@@ -112,7 +110,6 @@ func Test_ServicesGetNonExistentByName(t *testing.T) {
 }
 
 func Test_AllServiceEndpointsShouldReturnErrorWhenRequestUnauthorised(t *testing.T) {
-
 	unauthorisedClient := NewClient(&Config{HostAddress: kong401Server})
 
 	s, err := unauthorisedClient.Services().GetServiceByName("foo")

--- a/snis.go
+++ b/snis.go
@@ -27,8 +27,7 @@ type Snis struct {
 const SnisPath = "/snis/"
 
 func (snisClient *SnisClient) Create(snisRequest *SnisRequest) (*Sni, error) {
-
-	r, body, errs := newPost(snisClient.config, snisClient.config.HostAddress+SnisPath).Send(snisRequest).End()
+	r, body, errs := newPost(snisClient.config, SnisPath).Send(snisRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not create new sni, error: %v", errs)
 	}
@@ -51,8 +50,7 @@ func (snisClient *SnisClient) Create(snisRequest *SnisRequest) (*Sni, error) {
 }
 
 func (snisClient *SnisClient) GetByName(name string) (*Sni, error) {
-
-	r, body, errs := newGet(snisClient.config, snisClient.config.HostAddress+SnisPath+name).End()
+	r, body, errs := newGet(snisClient.config, SnisPath+name).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get sni, error: %v", errs)
 	}
@@ -75,8 +73,7 @@ func (snisClient *SnisClient) GetByName(name string) (*Sni, error) {
 }
 
 func (snisClient *SnisClient) List() (*Snis, error) {
-
-	r, body, errs := newGet(snisClient.config, snisClient.config.HostAddress+SnisPath).End()
+	r, body, errs := newGet(snisClient.config, SnisPath).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get snis, error: %v", errs)
 	}
@@ -95,8 +92,7 @@ func (snisClient *SnisClient) List() (*Snis, error) {
 }
 
 func (snisClient *SnisClient) DeleteByName(name string) error {
-
-	r, body, errs := newDelete(snisClient.config, snisClient.config.HostAddress+SnisPath+name).End()
+	r, body, errs := newDelete(snisClient.config, SnisPath+name).End()
 	if errs != nil {
 		return fmt.Errorf("could not delete sni, result: %v error: %v", r, errs)
 	}
@@ -109,8 +105,7 @@ func (snisClient *SnisClient) DeleteByName(name string) error {
 }
 
 func (snisClient *SnisClient) UpdateByName(name string, snisRequest *SnisRequest) (*Sni, error) {
-
-	r, body, errs := newPatch(snisClient.config, snisClient.config.HostAddress+SnisPath+name).Send(snisRequest).End()
+	r, body, errs := newPatch(snisClient.config, SnisPath+name).Send(snisRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update sni, error: %v", errs)
 	}

--- a/snis_test.go
+++ b/snis_test.go
@@ -1,3 +1,5 @@
+// +build all community
+
 package gokong
 
 import (

--- a/status.go
+++ b/status.go
@@ -30,8 +30,7 @@ type databaseStatus struct {
 }
 
 func (statusClient *StatusClient) Get() (*Status, error) {
-
-	_, body, errs := newGet(statusClient.config, statusClient.config.HostAddress+"/status").End()
+	_, body, errs := newGet(statusClient.config, "/status").End()
 	if errs != nil {
 		return nil, errors.New(fmt.Sprintf("Could not call get status, error: %v", errs))
 	}

--- a/status_test.go
+++ b/status_test.go
@@ -1,3 +1,5 @@
+// +build all community
+
 package gokong
 
 import (

--- a/targets.go
+++ b/targets.go
@@ -37,7 +37,7 @@ func (targetClient *TargetClient) CreateFromUpstreamName(name string, targetRequ
 }
 
 func (targetClient *TargetClient) CreateFromUpstreamId(id string, targetRequest *TargetRequest) (*Target, error) {
-	r, body, errs := newPost(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf(TargetsPath, id)).Send(targetRequest).End()
+	r, body, errs := newPost(targetClient.config, fmt.Sprintf(TargetsPath, id)).Send(targetRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not register the target, error: %v", errs)
 	}
@@ -68,7 +68,7 @@ func (targetClient *TargetClient) GetTargetsFromUpstreamId(id string) ([]*Target
 	data := &Targets{}
 
 	for {
-		r, body, errs := newGet(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf(TargetsPath, id)).End()
+		r, body, errs := newGet(targetClient.config, fmt.Sprintf(TargetsPath, id)).End()
 		if errs != nil {
 			return nil, fmt.Errorf("could not get targets, error: %v", errs)
 		}
@@ -100,7 +100,7 @@ func (targetClient *TargetClient) DeleteFromUpstreamByHostPort(upstreamNameOrId 
 }
 
 func (targetClient *TargetClient) DeleteFromUpstreamById(upstreamNameOrId string, id string) error {
-	r, body, errs := newDelete(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf(TargetsPath, upstreamNameOrId)+fmt.Sprintf("/%s", id)).End()
+	r, body, errs := newDelete(targetClient.config, fmt.Sprintf(TargetsPath, upstreamNameOrId)+fmt.Sprintf("/%s", id)).End()
 	if errs != nil {
 		return fmt.Errorf("could not delete the target, result: %v error: %v", r, errs)
 	}
@@ -121,7 +121,7 @@ func (targetClient *TargetClient) SetTargetFromUpstreamByHostPortAsHealthy(upstr
 }
 
 func (targetClient *TargetClient) SetTargetFromUpstreamByIdAsHealthy(upstreamNameOrId string, id string) error {
-	r, body, errs := newPost(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf(TargetsPath, upstreamNameOrId)+fmt.Sprintf("/%s/healthy", id)).Send("").End()
+	r, body, errs := newPost(targetClient.config, fmt.Sprintf(TargetsPath, upstreamNameOrId)+fmt.Sprintf("/%s/healthy", id)).Send("").End()
 	if errs != nil {
 		return fmt.Errorf("could not set the target as healthy, result: %v error: %v", r, errs)
 	}
@@ -142,7 +142,7 @@ func (targetClient *TargetClient) SetTargetFromUpstreamByHostPortAsUnhealthy(ups
 }
 
 func (targetClient *TargetClient) SetTargetFromUpstreamByIdAsUnhealthy(upstreamNameOrId string, id string) error {
-	r, body, errs := newPost(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf(TargetsPath, upstreamNameOrId)+fmt.Sprintf("/%s/unhealthy", id)).Send("").End()
+	r, body, errs := newPost(targetClient.config, fmt.Sprintf(TargetsPath, upstreamNameOrId)+fmt.Sprintf("/%s/unhealthy", id)).Send("").End()
 	if errs != nil {
 		return fmt.Errorf("could not set the target as unhealthy, result: %v error: %v", r, errs)
 	}
@@ -167,7 +167,7 @@ func (targetClient *TargetClient) GetTargetsWithHealthFromUpstreamId(id string) 
 	data := &Targets{}
 
 	for {
-		r, body, errs := newGet(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf("/upstreams/%s/health", id)).End()
+		r, body, errs := newGet(targetClient.config, fmt.Sprintf("/upstreams/%s/health", id)).End()
 		if errs != nil {
 			return nil, fmt.Errorf("could not get targets, error: %v", errs)
 		}

--- a/targets_test.go
+++ b/targets_test.go
@@ -1,3 +1,5 @@
+// +build all community
+
 package gokong
 
 import (

--- a/upstreams.go
+++ b/upstreams.go
@@ -86,8 +86,7 @@ func (upstreamClient *UpstreamClient) GetByName(name string) (*Upstream, error) 
 }
 
 func (upstreamClient *UpstreamClient) GetById(id string) (*Upstream, error) {
-
-	r, body, errs := newGet(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath+id).End()
+	r, body, errs := newGet(upstreamClient.config, UpstreamsPath+id).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get upstream, error: %v", errs)
 	}
@@ -110,8 +109,7 @@ func (upstreamClient *UpstreamClient) GetById(id string) (*Upstream, error) {
 }
 
 func (upstreamClient *UpstreamClient) Create(upstreamRequest *UpstreamRequest) (*Upstream, error) {
-
-	r, body, errs := newPost(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath).Send(upstreamRequest).End()
+	r, body, errs := newPost(upstreamClient.config, UpstreamsPath).Send(upstreamRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not create new upstream, error: %v", errs)
 	}
@@ -138,8 +136,7 @@ func (upstreamClient *UpstreamClient) DeleteByName(name string) error {
 }
 
 func (upstreamClient *UpstreamClient) DeleteById(id string) error {
-
-	r, body, errs := newDelete(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath+id).End()
+	r, body, errs := newDelete(upstreamClient.config, UpstreamsPath+id).End()
 	if errs != nil {
 		return fmt.Errorf("could not delete upstream, result: %v error: %v", r, errs)
 	}
@@ -152,8 +149,7 @@ func (upstreamClient *UpstreamClient) DeleteById(id string) error {
 }
 
 func (upstreamClient *UpstreamClient) List() (*Upstreams, error) {
-
-	r, body, errs := newGet(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath).End()
+	r, body, errs := newGet(upstreamClient.config, UpstreamsPath).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get upstreams, error: %v", errs)
 	}
@@ -176,8 +172,7 @@ func (upstreamClient *UpstreamClient) UpdateByName(name string, upstreamRequest 
 }
 
 func (upstreamClient *UpstreamClient) UpdateById(id string, upstreamRequest *UpstreamRequest) (*Upstream, error) {
-
-	r, body, errs := newPatch(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath+id).Send(upstreamRequest).End()
+	r, body, errs := newPatch(upstreamClient.config, UpstreamsPath+id).Send(upstreamRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update upstream, error: %v", errs)
 	}

--- a/upstreams_test.go
+++ b/upstreams_test.go
@@ -1,3 +1,5 @@
+// +build all community
+
 package gokong
 
 import (

--- a/workspaces.go
+++ b/workspaces.go
@@ -1,0 +1,267 @@
+package gokong
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type WorkspaceClient struct {
+	config *Config
+}
+
+type WorkspaceRequest struct {
+	Name    *string `json:"name" yaml:"name"`
+	Comment *string `json:"comment" yaml:"comment"`
+}
+
+type WorkspaceEntitiesRequest struct {
+	Entities *string `json:"entities" yaml:"entities"`
+}
+
+type Workspace struct {
+	Id      *string     `json:"id" yaml:"id"`
+	Name    *string     `json:"name" yaml:"name"`
+	Comment *string     `json:"comment" yaml:"comment"`
+	Config  interface{} `json:"config,omitempty" yaml:"config,omitempty"`
+	Meta    interface{} `json:"meta,omitempty" yaml:"meta,omitempty"`
+}
+
+type Workspaces struct {
+	Data   []*Workspace `json:"data" yaml:"data,omitempty"`
+	Next   *string      `json:"next" yaml:"next,omitempty"`
+	Offset string       `json:"offset,omitempty" yaml:"offset,omitempty"`
+}
+
+type WorkspaceQueryString struct {
+	Offset *string `json:"offset,omitempty" yaml:"offset,omitempty"`
+	Size   int     `json:"size" yaml:"size,omitempty"`
+}
+
+type WorkspaceEntity struct {
+	WorkspaceId      *string `json:"workspace_id" yaml:"workspace_id"`
+	WorkspaceName    *string `json:"workspace_name" yaml:"workspace_name"`
+	EntityId         *string `json:"entity_id" yaml:"entity_id"`
+	EntityType       *string `json:"entity_type" yaml:"entity_type"`
+	UniqueFieldName  *string `json:"unique_field_name" yaml:"unique_field_name"`
+	UniqueFieldValue *string `json:"unique_field_value" yaml:"unique_field_value"`
+}
+
+type WorkspaceEntities struct {
+	Data  []*WorkspaceEntity `json:"data" yaml:"data,omitempty"`
+	Total int                `json:"total,omitempty" yaml:"total,omitempty"`
+}
+
+const WorkspacesPath = "/workspaces/"
+
+func (workspaceClient *WorkspaceClient) GetByName(name string) (*Workspace, error) {
+	return workspaceClient.Get(name)
+}
+
+func (workspaceClient *WorkspaceClient) Get(id string) (*Workspace, error) {
+	r, body, errs := newRawGet(workspaceClient.config, workspaceClient.config.HostAddress+WorkspacesPath+id).End()
+	if errs != nil {
+		return nil, fmt.Errorf("could not get workspace, error: %v", errs)
+	}
+
+	if r.StatusCode == 400 {
+		return nil, fmt.Errorf("bad request, message from kong: %s", body)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	workspace := &Workspace{}
+	err := json.Unmarshal([]byte(body), workspace)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse workspace workspace response, error: %v", err)
+	}
+
+	if workspace.Id == nil {
+		return nil, nil
+	}
+
+	return workspace, nil
+}
+
+func (workspaceClient *WorkspaceClient) List(query *WorkspaceQueryString) ([]*Workspace, error) {
+	workspaces := make([]*Workspace, 0)
+
+	if query.Size < 100 {
+		query.Size = 100
+	}
+
+	if query.Size > 1000 {
+		query.Size = 1000
+	}
+
+	for {
+		data := &Workspaces{}
+
+		r, body, errs := newRawGet(workspaceClient.config, workspaceClient.config.HostAddress+WorkspacesPath).Query(*query).End()
+		if errs != nil {
+			return nil, fmt.Errorf("could not get workspaces, error: %v", errs)
+		}
+
+		if r.StatusCode == 400 {
+			return nil, fmt.Errorf("bad request, message from kong: %s", body)
+		}
+
+		if r.StatusCode == 401 || r.StatusCode == 403 {
+			return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+		}
+
+		err := json.Unmarshal([]byte(body), data)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse workspaces list response, error: %v", err)
+		}
+
+		workspaces = append(workspaces, data.Data...)
+
+		if data.Next == nil || data.Next == String("") {
+			break
+		}
+
+		query.Offset = &data.Offset
+	}
+
+	return workspaces, nil
+}
+
+func (workspaceClient *WorkspaceClient) Create(workspaceRequest *WorkspaceRequest) (*Workspace, error) {
+	r, body, errs := newRawPost(workspaceClient.config, workspaceClient.config.HostAddress+WorkspacesPath).Send(workspaceRequest).End()
+	if errs != nil {
+		return nil, fmt.Errorf("could not create new workspace, error: %v", errs)
+	}
+
+	if r.StatusCode == 400 {
+		return nil, fmt.Errorf("bad request, message from kong: %s", body)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	workspace := &Workspace{}
+	err := json.Unmarshal([]byte(body), workspace)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse workspace creation response, error: %v kong response: %s", err, body)
+	}
+
+	if workspace.Id == nil {
+		return nil, fmt.Errorf("could not create workspace, err: %v", body)
+	}
+
+	return workspace, nil
+}
+
+func (workspaceClient *WorkspaceClient) Update(workspaceRequest *WorkspaceRequest) (*Workspace, error) {
+	requestPath := fmt.Sprintf(
+		"%s%s%s",
+		workspaceClient.config.HostAddress,
+		WorkspacesPath,
+		workspaceClient.config.Workspace,
+	)
+	r, body, errs := newRawPatch(workspaceClient.config, requestPath).Send(workspaceRequest).End()
+	if errs != nil {
+		return nil, fmt.Errorf("could not update workspace, error: %v", errs)
+	}
+
+	if r.StatusCode == 400 {
+		return nil, fmt.Errorf("bad request, message from kong: %s", body)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	workspace := &Workspace{}
+	err := json.Unmarshal([]byte(body), workspace)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse workspace update response, error: %v kong response: %s", err, body)
+	}
+
+	if workspace.Id == nil {
+		return nil, fmt.Errorf("could not update workspace, error: %v", body)
+	}
+
+	return workspace, nil
+}
+
+func (workspaceClient *WorkspaceClient) Delete() error {
+	requestPath := fmt.Sprintf(
+		"%s%s%s",
+		workspaceClient.config.HostAddress,
+		WorkspacesPath,
+		workspaceClient.config.Workspace,
+	)
+	r, body, errs := newRawDelete(workspaceClient.config, requestPath).End()
+	if errs != nil {
+		return fmt.Errorf("could not delete workspace, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 400 {
+		return fmt.Errorf("bad request, message from kong: %s", body)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	return nil
+}
+
+func (workspaceClient *WorkspaceClient) ListEntities() ([]*WorkspaceEntity, error) {
+	requestPath := fmt.Sprintf(
+		"%s%s/entities",
+		workspaceClient.config.HostAddress+WorkspacesPath,
+		workspaceClient.config.Workspace,
+	)
+	r, body, errs := newRawGet(workspaceClient.config, requestPath).End()
+	if errs != nil {
+		return nil, fmt.Errorf("could not get workspaces, error: %v", errs)
+	}
+
+	if r.StatusCode == 400 {
+		return nil, fmt.Errorf("bad request, message from kong: %s", body)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	workspaceEntities := &WorkspaceEntities{}
+	err := json.Unmarshal([]byte(body), workspaceEntities)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse workspaces list response, error: %v", err)
+	}
+
+	return workspaceEntities.Data, nil
+}
+
+func (workspaceClient *WorkspaceClient) DeleteMultipleEntitiesFromWorkspace(entityIds []string) error {
+	requestPath := fmt.Sprintf(
+		"%s%s/entities",
+		workspaceClient.config.HostAddress+WorkspacesPath,
+		workspaceClient.config.Workspace,
+	)
+	workspaceEntitiesRequest := &WorkspaceEntitiesRequest{
+		Entities: String(strings.Join(entityIds, ",")),
+	}
+
+	r, body, errs := newRawDelete(workspaceClient.config, requestPath).Send(workspaceEntitiesRequest).End()
+	if errs != nil {
+		return fmt.Errorf("could not delete workspace entities, error: %v", errs)
+	}
+
+	if r.StatusCode == 400 {
+		return fmt.Errorf("bad request, message from kong: %s", body)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	return nil
+}

--- a/workspaces_test.go
+++ b/workspaces_test.go
@@ -1,0 +1,241 @@
+// +build all enterprise
+
+package gokong
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_WorkspaceClient_Get(t *testing.T) {
+	workspaceRequest := &WorkspaceRequest{
+		Name: String(fmt.Sprintf("workspace-name-%s", uuid.NewV4().String())),
+	}
+
+	client := NewClient(NewDefaultConfig())
+	createdWorkspace, err := client.Workspaces().Create(workspaceRequest)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, createdWorkspace)
+	assert.EqualValues(t, createdWorkspace.Name, workspaceRequest.Name)
+
+	result, err := client.Workspaces().Get(*createdWorkspace.Id)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, createdWorkspace, result)
+
+	err = client.Workspaces().Delete()
+	assert.Nil(t, err)
+}
+
+func Test_WorkspaceClient_List(t *testing.T) {
+	workspaceRequest := &WorkspaceRequest{}
+	createdWorkspaces := &Workspaces{}
+	client := NewClient(NewDefaultConfig())
+
+	for i := 0; i < 5; i++ {
+		workspaceRequest.Name = String(fmt.Sprintf("workspace-name-%s", uuid.NewV4().String()))
+		createdWorkspace, err := client.Workspaces().Create(workspaceRequest)
+		assert.Nil(t, err)
+		assert.NotNil(t, createdWorkspace)
+
+		createdWorkspaces.Data = append(createdWorkspaces.Data, createdWorkspace)
+	}
+
+	result, err := client.Workspaces().List(&WorkspaceQueryString{})
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+	assert.Subset(t, result, createdWorkspaces.Data)
+
+	for range createdWorkspaces.Data {
+		err = client.Workspaces().Delete()
+		assert.Nil(t, err)
+	}
+}
+
+func Test_WorkspaceClient_Update(t *testing.T) {
+	config := NewDefaultConfig()
+	config.Workspace = "default"
+	client := NewClient(config)
+	workspaceRequest := &WorkspaceRequest{
+		Name: String(fmt.Sprintf("workspace-name-%s", uuid.NewV4().String())),
+	}
+	createdWorkspace, err := client.Workspaces().Create(workspaceRequest)
+	assert.Nil(t, err)
+	assert.NotNil(t, createdWorkspace)
+
+	config.Workspace = *workspaceRequest.Name
+	newWorkspaceClient := NewClient(config)
+	workspaceRequest.Comment = String("This is a comment")
+	updatedWorkspace, err := newWorkspaceClient.Workspaces().Update(workspaceRequest)
+	assert.Nil(t, err)
+	assert.NotNil(t, updatedWorkspace)
+
+	result, err := client.Workspaces().Get(*createdWorkspace.Id)
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, updatedWorkspace, result)
+
+	err = newWorkspaceClient.Workspaces().Delete()
+	assert.Nil(t, err)
+}
+
+func Test_Workspaces_GetNonExistent(t *testing.T) {
+	client := NewClient(NewDefaultConfig())
+	workspace, err := client.Workspaces().Get(uuid.NewV4().String())
+
+	assert.Nil(t, workspace)
+	assert.Nil(t, err)
+}
+
+func Test_WorkspaceClient_ListEntities(t *testing.T) {
+	workspaceRequest := &WorkspaceRequest{
+		Name: String(fmt.Sprintf("workspace-name-%s", uuid.NewV4().String())),
+	}
+
+	client := NewClient(NewDefaultConfig())
+	createdWorkspace, err := client.Workspaces().Create(workspaceRequest)
+	assert.NotNil(t, createdWorkspace)
+	assert.Nil(t, err)
+
+	os.Setenv(EnvKongWorkspace, *workspaceRequest.Name)
+	workspaceClient := NewClient(NewDefaultConfig())
+
+	serviceRequest := &ServiceRequest{
+		Name:     String(fmt.Sprintf("service-name-%s", uuid.NewV4().String())),
+		Protocol: String("http"),
+		Host:     String("foo.com"),
+		Port:     Int(8080),
+	}
+	createdService, err := workspaceClient.Services().Create(serviceRequest)
+
+	assert.NotNil(t, createdService)
+	assert.Nil(t, err)
+
+	newWorkspaceEntities, err := workspaceClient.Workspaces().ListEntities()
+	assert.Len(t, newWorkspaceEntities, 2)
+
+	for _, workspaceEntity := range newWorkspaceEntities {
+		if workspaceEntity.UniqueFieldName == String("name") {
+			assert.Equal(t, *workspaceEntity.UniqueFieldValue, *createdService.Name)
+		}
+		if workspaceEntity.UniqueFieldName == String("id") {
+			assert.Equal(t, *workspaceEntity.UniqueFieldValue, *createdService.Name)
+		}
+	}
+
+	err = workspaceClient.Services().DeleteServiceById(*createdService.Id)
+	assert.Nil(t, err)
+
+	err = workspaceClient.Workspaces().Delete()
+	assert.Nil(t, err)
+}
+
+func Test_WorkspaceClient_ShouldNotAllowToDeleteWorkspaceWithEntity(t *testing.T) {
+	workspaceRequest := &WorkspaceRequest{
+		Name: String("testingworkspace"),
+	}
+
+	client := NewClient(NewDefaultConfig())
+	createdWorkspace, err := client.Workspaces().Create(workspaceRequest)
+	assert.NotNil(t, createdWorkspace)
+	assert.Nil(t, err)
+
+	os.Setenv(EnvKongWorkspace, *workspaceRequest.Name)
+	workspaceClient := NewClient(NewDefaultConfig())
+
+	serviceRequest := &ServiceRequest{
+		Name:     String(fmt.Sprintf("service-name-%s", uuid.NewV4().String())),
+		Protocol: String("http"),
+		Host:     String("foo.com"),
+		Port:     Int(8080),
+	}
+	createdService, err := workspaceClient.Services().Create(serviceRequest)
+	assert.NotNil(t, createdService)
+	assert.Nil(t, err)
+
+	newWorkspaceEntities, err := workspaceClient.Workspaces().ListEntities()
+	assert.Len(t, newWorkspaceEntities, 2)
+
+	err = workspaceClient.Workspaces().Delete()
+	errorMessage := "bad request, message from kong: {\"message\":\"Workspace is not empty\"}"
+	assert.Equal(t, err.Error(), errorMessage)
+}
+
+func Test_WorkspaceClient_Delete(t *testing.T) {
+	workspaceRequest := &WorkspaceRequest{
+		Name: String(fmt.Sprintf("workspace-name-%s", uuid.NewV4().String())),
+	}
+
+	config := NewDefaultConfig()
+	config.Workspace = *workspaceRequest.Name
+	client := NewClient(config)
+	createdWorkspace, err := client.Workspaces().Create(workspaceRequest)
+	assert.Nil(t, err)
+	assert.NotNil(t, createdWorkspace)
+	assert.EqualValues(t, createdWorkspace.Name, workspaceRequest.Name)
+
+	result, err := client.Workspaces().Get(*createdWorkspace.Id)
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, createdWorkspace, result)
+
+	err = client.Workspaces().Delete()
+	assert.Nil(t, err)
+}
+
+func Test_WorkspaceClient_DeleteMultipleEntitiesFromWorkspaceByIds(t *testing.T) {
+	workspaceRequest := &WorkspaceRequest{
+		Name: String(fmt.Sprintf("workspace-name-%s", uuid.NewV4().String())),
+	}
+
+	client := NewClient(NewDefaultConfig())
+	createdWorkspace, err := client.Workspaces().Create(workspaceRequest)
+	assert.NotNil(t, createdWorkspace)
+	assert.Nil(t, err)
+
+	os.Setenv(EnvKongWorkspace, *workspaceRequest.Name)
+	workspaceClient := NewClient(NewDefaultConfig())
+
+	serviceRequest := &ServiceRequest{
+		Name:     String(fmt.Sprintf("service-name-%s", uuid.NewV4().String())),
+		Protocol: String("http"),
+		Host:     String("foo.com"),
+		Port:     Int(8080),
+	}
+	createdService, err := workspaceClient.Services().Create(serviceRequest)
+
+	assert.NotNil(t, createdService)
+	assert.Nil(t, err)
+
+	newWorkspaceEntities, err := workspaceClient.Workspaces().ListEntities()
+	assert.Len(t, newWorkspaceEntities, 2)
+
+	entityIds := []string{}
+	for _, workspaceEntity := range newWorkspaceEntities {
+		entityIds = append(entityIds, *workspaceEntity.EntityId)
+		if workspaceEntity.UniqueFieldName == String("name") {
+			assert.Equal(t, *workspaceEntity.UniqueFieldValue, *createdService.Name)
+		}
+		if workspaceEntity.UniqueFieldName == String("id") {
+			assert.Equal(t, *workspaceEntity.UniqueFieldValue, *createdService.Name)
+		}
+	}
+
+	err = workspaceClient.Workspaces().DeleteMultipleEntitiesFromWorkspace(
+		entityIds,
+	)
+	assert.Nil(t, err)
+
+	newWorkspaceEntities, err = workspaceClient.Workspaces().ListEntities()
+	assert.Nil(t, err)
+	assert.Len(t, newWorkspaceEntities, 0)
+
+	err = workspaceClient.Workspaces().Delete()
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
# Added support to run tests with custom Dockerfile

In order to support Kong EE we should be able to run custom containers
to our tests.

To achieve this, it's now allowed to provide a custom Dockerfile to be
used to build and run the Kong container.

Some notes:

- For now, it's only possible to set the desired Dockerfile using the
KONG_DOCKERFILE_PATH env var

- In order to avoid issues with Kong CE users, we added tags to the
tests, segregating them among "all", "community" and "enterprise", and,
therefore, allowing us to run each "kind" of test sepparately. This
means that the `make test` behavior remains the same and there are now 2
new commands: `make test-all` and `make test-enterprise`.

All of this was made necessary so we could write and run tests for
Kong's "Workspace" feature, which is only available on the Enterprise
version.

---

# Added support for Kong EE workspaces

[Kong EE Workspaces Reference](https://docs.konghq.com/enterprise/1.3-x/admin-api/workspaces/reference/)

Following the reference above, we've implemented support for this Kong
EE feature called "Workspaces".

This feature should not add any kind of backwards compatibility issue
with clients using Kong CE.

Added support for:

* Manipulating Workspaces (CRUD + extra actions supported by the API)
* Creating clients for specific workspaces, therefore allowing us to
only work on the entities of the specified workspace