### PR TITLE
Fix upstream for targets

### DIFF
--- a/targets.go
+++ b/targets.go
@@ -15,12 +15,12 @@ type TargetRequest struct {
 }
 
 type Target struct {
-	Id        *string  `json:"id,omitempty" yaml:"id,omitempty"`
-	CreatedAt *float32 `json:"created_at" yaml:"created_at"`
-	Target    *string  `json:"target" yaml:"target"`
-	Weight    *int     `json:"weight" yaml:"weight"`
-	Upstream  *string  `json:"upstream" yaml:"upstream"`
-	Health    *string  `json:"health" yaml:"health"`
+	Id         *string  `json:"id,omitempty" yaml:"id,omitempty"`
+	CreatedAt  *float32 `json:"created_at" yaml:"created_at"`
+	Target     *string  `json:"target" yaml:"target"`
+	Weight     *int     `json:"weight" yaml:"weight"`
+	UpstreamId *string  `json:"upstream_id" yaml:"upstream_id"`
+	Health     *string  `json:"health" yaml:"health"`
 }
 
 type Targets struct {

--- a/targets_test.go
+++ b/targets_test.go
@@ -102,6 +102,7 @@ func TestTargets_Create(t *testing.T) {
 	assert.True(t, *createdTarget.Id != "")
 	assert.Equal(t, *createdTarget.Target, targetRequest.Target)
 	assert.Equal(t, *createdTarget.Weight, targetRequest.Weight)
+	assert.Equal(t, *createdTarget.UpstreamId, createdUpstream.Id)
 
 	client.Targets().DeleteFromUpstreamById(createdUpstream.Id, *createdTarget.Id)
 	client.Upstreams().DeleteById(createdUpstream.Id)


### PR DESCRIPTION
In Kong pre-1.0.0, targets have `upstream_id` and not `upstream`. https://docs.konghq.com/0.14.x/admin-api/#add-target